### PR TITLE
Caching issue while reorder sorting

### DIFF
--- a/src/system/modules/metamodels/MetaModel.php
+++ b/src/system/modules/metamodels/MetaModel.php
@@ -175,7 +175,7 @@ class MetaModel implements IMetaModel
 
 		// ensure proper integer ids for SQL injection safety reasons.
 		$strIdList = implode(',', array_map('intval', $arrIds));
-		$objRow = $objDB->execute('SELECT * FROM ' . $this->getTableName() . ' WHERE id IN (' . $strIdList . ') ORDER BY FIELD(id,' . $strIdList . ')');
+		$objRow = $objDB->executeUncached('SELECT * FROM ' . $this->getTableName() . ' WHERE id IN (' . $strIdList . ') ORDER BY FIELD(id,' . $strIdList . ')');
 		if($objRow->numRows == 0)
 		{
 			return array();


### PR DESCRIPTION
I found this issue while debugging drag&drop sorting of a mm_\* table in the backend.

This is the method used to reorder the sorting field in metamodels:
https://github.com/MetaModels/DC_General/blob/master/system/modules/generalDriver/GeneralControllerDefault.php#L1706

After the call of `reorderSorting`, the sorting field gets fetched again (from cache) and produces a wrong sorting, because of the cached result set from before sorting.

If I use `executeUncached(...)` on `fetchRows(...)` it works as expected.

Thx to @discordier & @stefanheimes
