### PR TITLE
Changed inheritance fom ContentElement to Module for the MM FE-Module

### DIFF
--- a/src/system/modules/metamodels/MetaModels/FrontendIntegration/Module/ModelList.php
+++ b/src/system/modules/metamodels/MetaModels/FrontendIntegration/Module/ModelList.php
@@ -25,7 +25,7 @@ use MetaModels\ItemList;
  * @subpackage Frontend
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  */
-class ModelList extends \ContentElement
+class ModelList extends \Module
 {
 	/**
 	 * Template


### PR DESCRIPTION
THe FE-Module should extend \Module and not \ContentElement
