### PR TITLE
Change order the meta files are loaded.

### DIFF
--- a/src/system/modules/metamodels/ToolboxFile.php
+++ b/src/system/modules/metamodels/ToolboxFile.php
@@ -353,8 +353,8 @@ class ToolboxFile
 
 			$arrProcessed[] = $strDir;
 
-			$this->parseMetaFile($strDir, $this->getBaseLanguage());
 			$this->parseMetaFile($strDir, $this->getFallbackLanguage());
+			$this->parseMetaFile($strDir, $this->getBaseLanguage());
 			$this->parseMetaFile($strDir);
 		}
 	}


### PR DESCRIPTION
The fallback language must be loaded before the base language, otherwise it will overwrite all entries with the fallback language.
