### PR TITLE
Fixed initialize Bug

### DIFF
--- a/src/system/modules/metamodels/MetaModels/BackendIntegration/Boot.php
+++ b/src/system/modules/metamodels/MetaModels/BackendIntegration/Boot.php
@@ -154,7 +154,7 @@ class Boot
 	public static function perform()
 	{
 		// Do not execute anything if we are on the index page because no User is logged in
-		if (\Environment::get('script') == 'contao/index.php')
+		if (strpos(\Environment::getInstance()->script, 'contao/index.php') !== false)
 		{
 			return;
 		}


### PR DESCRIPTION
The problem is, that Metamodels is nearly completly initialized without a logged in Backend User.

I fxed it with checking if the script is still executed from the index.php file. Same as the original contao authenticate function does.
