### PR TITLE
[tng] ToolboxFile should check if the file exits

### DIFF
--- a/src/MetaModels/Helper/ToolboxFile.php
+++ b/src/MetaModels/Helper/ToolboxFile.php
@@ -535,8 +535,7 @@ class ToolboxFile
                 }
                 $arrSource['src'] = $strSrc;
 
-                if (file_exists(TL_ROOT . '/' . urldecode($strSrc)))
-                {
+                if (file_exists(TL_ROOT . '/' . urldecode($strSrc))) {
                     $size            = getimagesize(TL_ROOT . '/' . urldecode($strSrc));
                     $arrSource['lb'] = 'lb'.$this->getLightboxId();
                     $arrSource['w']  = $size[0];


### PR DESCRIPTION
Fixed file not found problem with `getimagesize`

Stack Trace:

```
Warning: getimagesize(E:\www\2014/files/media/irgendeinbild.jpg): failed to open stream: No such file or directory in E:\www\system\modules\metamodels\classes\src\MetaModels\Helper\ToolboxFile.php on line 538

#0 [internal function]: __error(2, 'getimagesize(E:...', 'E:\www\...', 538, Array)
#1 E:\www\system\modules\metamodels\classes\src\MetaModels\Helper\ToolboxFile.php(538): getimagesize('E:\www\...')
#2 E:\www\system\modules\metamodels\classes\src\MetaModels\Helper\ToolboxFile.php(794): MetaModels\Helper\ToolboxFile->fetchAdditionalData()
#3 E:\www\system\modules\metamodelsattribute_file\classes\src\MetaModels\Attribute\File\File.php(335): MetaModels\Helper\ToolboxFile->resolveFiles()
#4 E:\www\system\modules\metamodels\classes\src\MetaModels\Attribute\Base.php(405): MetaModels\Attribute\File\File->prepareTemplate(Object(MetaModels\Render\Template), Array, Object(MetaModels\Render\Setting\Simple))
#5 E:\www\system\modules\metamodels\classes\src\MetaModels\Attribute\Base.php(428): MetaModels\Attribute\Base->parseValue(Array, 'text', Object(MetaModels\Render\Setting\Simple))
#6 E:\www\system\modules\metamodels\classes\src\MetaModels\Item.php(114): MetaModels\Attribute\Base->parseValue(Array, 'text', NULL)
#7 E:\www\system\modules\metamodels\classes\src\MetaModels\Item.php(553): MetaModels\Item->internalParseAttribute(Object(MetaModels\Attribute\File\File), 'text', Object(MetaModels\Render\Setting\Collection))
#8 E:\www\system\modules\metamodels\classes\src\MetaModels\DcGeneral\Events\MetaModel\RenderItem.php(139): MetaModels\Item->parseAttribute('singleSRC', 'text', Object(MetaModels\Render\Setting\Collection))
#9 [internal function]: MetaModels\DcGeneral\Events\MetaModel\RenderItem::getReadableValue(Object(ContaoCommunityAlliance\DcGeneral\View\Event\RenderReadablePropertyValueEvent), 'dc-general.view...', Object(Symfony\Component\EventDispatcher\EventDispatcher))
#10 E:\www\system\modules\symfony-event-dispatcher\classes\Symfony\Component\EventDispatcher\EventDispatcher.php(164): call_user_func(Array, Object(ContaoCommunityAlliance\DcGeneral\View\Event\RenderReadablePropertyValueEvent), 'dc-general.view...', Object(Symfony\Component\EventDispatcher\EventDispatcher))
#11 E:\www\system\modules\symfony-event-dispatcher\classes\Symfony\Component\EventDispatcher\EventDispatcher.php(53): Symfony\Component\EventDispatcher\EventDispatcher->doDispatch(Array, 'dc-general.view...', Object(ContaoCommunityAlliance\DcGeneral\View\Event\RenderReadablePropertyValueEvent))
#12 E:\www\system\modules\dc-general\classes\src\ContaoCommunityAlliance\DcGeneral\Event\EventPropagator.php(119): Symfony\Component\EventDispatcher\EventDispatcher->dispatch('dc-general.view...', Object(ContaoCommunityAlliance\DcGeneral\View\Event\RenderReadablePropertyValueEvent))
#13 E:\www\system\modules\dc-general\classes\src\ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\BaseView.php(2299): ContaoCommunityAlliance\DcGeneral\Event\EventPropagator->dispatch('dc-general.view...', Object(ContaoCommunityAlliance\DcGeneral\View\Event\RenderReadablePropertyValueEvent))
#14 E:\www\system\modules\dc-general\classes\src\ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\BaseView.php(2216): ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\BaseView->getReadableFieldValue(Object(ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\DefaultProperty), Object(MetaModels\DcGeneral\Data\Model), 'a:1:{i:0;s:36:"...')
#15 E:\www\system\modules\dc-general\classes\src\ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ListView.php(170): ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\BaseView->formatModel(Object(MetaModels\DcGeneral\Data\Model))
#16 E:\www\system\modules\dc-general\classes\src\ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ListView.php(189): ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ListView->setListViewLabel(Object(ContaoCommunityAlliance\DcGeneral\Data\DefaultCollection), Array)
#17 E:\www\system\modules\dc-general\classes\src\ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ListView.php(307): ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ListView->viewList(Object(ContaoCommunityAlliance\DcGeneral\Data\DefaultCollection))
#18 [internal function]: ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ListView->showAll()
#19 E:\www\system\modules\dc-general\classes\src\ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\BaseView.php(155): call_user_func_array(Array, Array)
#20 [internal function]: ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\BaseView->handleAction(Object(ContaoCommunityAlliance\DcGeneral\Event\ActionEvent), 'dc-general.acti...', Object(Symfony\Component\EventDispatcher\EventDispatcher))
#21 E:\www\system\modules\symfony-event-dispatcher\classes\Symfony\Component\EventDispatcher\EventDispatcher.php(164): call_user_func(Array, Object(ContaoCommunityAlliance\DcGeneral\Event\ActionEvent), 'dc-general.acti...', Object(Symfony\Component\EventDispatcher\EventDispatcher))
#22 E:\www\system\modules\symfony-event-dispatcher\classes\Symfony\Component\EventDispatcher\EventDispatcher.php(53): Symfony\Component\EventDispatcher\EventDispatcher->doDispatch(Array, 'dc-general.acti...', Object(ContaoCommunityAlliance\DcGeneral\Event\ActionEvent))
#23 E:\www\system\modules\dc-general\classes\src\ContaoCommunityAlliance\DcGeneral\Event\EventPropagator.php(119): Symfony\Component\EventDispatcher\EventDispatcher->dispatch('dc-general.acti...', Object(ContaoCommunityAlliance\DcGeneral\Event\ActionEvent))
#24 E:\www\system\modules\dc-general\classes\src\ContaoCommunityAlliance\DcGeneral\Controller\DefaultController.php(129): ContaoCommunityAlliance\DcGeneral\Event\EventPropagator->dispatch('dc-general.acti...', Object(ContaoCommunityAlliance\DcGeneral\Event\ActionEvent))
#25 E:\www\system\modules\metamodels\classes\src\MetaModels\BackendIntegration\Module.php(238): ContaoCommunityAlliance\DcGeneral\Controller\DefaultController->handle(Object(ContaoCommunityAlliance\DcGeneral\Action))
#26 E:\www\system\modules\metamodels\classes\src\MetaModels\BackendIntegration\Module.php(263): MetaModels\BackendIntegration\Module->runDC()
#27 E:\www\system\modules\metamodels\classes\src\MetaModels\BackendIntegration\Module.php(283): MetaModels\BackendIntegration\Module->performNormal()
#28 E:\www\system\modules\core\classes\Backend.php(272): MetaModels\BackendIntegration\Module->generate()
#29 E:\www\contao\main.php(142): Contao\Backend->getBackendModule('metamodel_mm_sc...')
#30 E:\www\contao\main.php(293): Main->run()
#31 {main}

```
