### PR TITLE
Authenticate backend user, if necessary.

### DIFF
--- a/src/MetaModels/BackendIntegration/ViewCombinations.php
+++ b/src/MetaModels/BackendIntegration/ViewCombinations.php
@@ -62,8 +62,13 @@ class ViewCombinations
     protected static function getUser()
     {
         if (TL_MODE == 'BE') {
-            return \BackendUser::getInstance();
+            $user = \BackendUser::getInstance();
+            if (empty($user->id)) {
+                $user->authenticate();
+            }
+            return $user;
         } elseif (TL_MODE == 'FE') {
+            // TODO maybe here is $user->authenticate() required too?
             return \FrontendUser::getInstance();
         }
         return null;


### PR DESCRIPTION
When using avisota, the `loadDataContainer` is called the first time within the `initializeSystem` hook. At this point the backend user is not authenticated yet, so there is no BE menu item.
