### PR TITLE
wrong parameter

### DIFF
--- a/src/MetaModels/DcGeneral/Events/Table/Attribute/Subscriber.php
+++ b/src/MetaModels/DcGeneral/Events/Table/Attribute/Subscriber.php
@@ -280,7 +280,7 @@ class Subscriber extends BaseSubscriber
      */
     protected function buildWidget(BuildWidgetEvent $event)
     {
-        $metaModel = $this->getMetaModelByModelPid($event->getModel()->getProperty('pid'));
+        $metaModel = $this->getMetaModelByModelPid($event->getModel());
 
         Helper::prepareLanguageAwareWidget(
             $event->getEnvironment(),


### PR DESCRIPTION
The method getMetaModelByModelPid() needs as first parameter an model instance instead of the pid property