### PR TITLE
Do not loose result of previously called hooks.

### DIFF
--- a/src/MetaModels/Attribute/Base.php
+++ b/src/MetaModels/Attribute/Base.php
@@ -168,7 +168,7 @@ abstract class Base implements IAttribute
 
                 $arrResult = $objCallback->$strMethod(
                     $this,
-                    $arrBaseFormatted,
+                    $arrResult,
                     $arrRowData,
                     $strOutputFormat,
                     $objSettings


### PR DESCRIPTION
The parseValue hooks looses the results of a hook if multiple hooks are registered.