### PR TITLE
Variant Improvements

### DIFF
--- a/src/MetaModels/DcGeneral/DataDefinition/Palette/Condition/Property/IsVariantAttribute.php
+++ b/src/MetaModels/DcGeneral/DataDefinition/Palette/Condition/Property/IsVariantAttribute.php
@@ -54,6 +54,10 @@ class IsVariantAttribute implements PropertyConditionInterface
             return !in_array($property->getName(), array_keys($metaModel->getInVariantAttributes()));
         }
 
+        if ($metaModel->hasVariants() && $nativeItem->isVariantBase()) {
+            return in_array($property->getName(), array_keys($metaModel->getInVariantAttributes()));
+        }
+
         return true;
     }
 

--- a/src/MetaModels/DcGeneral/Dca/Builder/Builder.php
+++ b/src/MetaModels/DcGeneral/Dca/Builder/Builder.php
@@ -629,9 +629,15 @@ class Builder
 
         $relationship = $this->getRootCondition($container, $definition);
 
+        if(\Input::get('pid')) {
+            $parentValue = IdSerializer::fromSerialized(Input::get('pid'))->getId();
+        } else {
+            $parentValue = '0';
+        }
+
         if (!$relationship->getSetters()) {
             $relationship
-                ->setSetters(array(array('property' => 'pid', 'value' => '0')));
+                ->setSetters(array(array('property' => 'pid', 'value' => $parentValue)));
         }
 
         $builder = FilterBuilder::fromArrayForRoot((array) $relationship->getFilterArray())->getFilter();

--- a/src/MetaModels/DcGeneral/Dca/Builder/Builder.php
+++ b/src/MetaModels/DcGeneral/Dca/Builder/Builder.php
@@ -18,11 +18,13 @@
 
 namespace MetaModels\DcGeneral\Dca\Builder;
 
+use Contao\Input;
 use ContaoCommunityAlliance\Contao\Bindings\ContaoEvents;
 use ContaoCommunityAlliance\Contao\Bindings\Events\Image\ResizeImageEvent;
 use ContaoCommunityAlliance\Contao\Bindings\Events\System\LoadLanguageFileEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetOperationButtonEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetPasteButtonEvent;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\IdSerializer;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\DefaultModelRelationshipDefinition;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\ModelRelationshipDefinitionInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\View\CommandInterface;
@@ -629,7 +631,7 @@ class Builder
 
         $relationship = $this->getRootCondition($container, $definition);
 
-        if(\Input::get('pid')) {
+        if(Input::get('pid')) {
             $parentValue = IdSerializer::fromSerialized(Input::get('pid'))->getId();
         } else {
             $parentValue = '0';
@@ -642,7 +644,7 @@ class Builder
 
         $builder = FilterBuilder::fromArrayForRoot((array) $relationship->getFilterArray())->getFilter();
 
-        $builder->andPropertyEquals('pid', 0);
+        $builder->andPropertyEquals('pid', $parentValue);
 
         $relationship
             ->setFilterArray($builder->getAllAsArray());


### PR DESCRIPTION
This PR adds the possibility to use Variant MetaModels as Child-Tables.
It also removes Variant-Attribute from the VariantBase, so we only base attributes and not the variant attributes in the Base.

@discordier Can you have a fast look on it, we need it for an project at the moment.