### PR TITLE
Decoding filter parameters now in HybridList

### DIFF
--- a/src/MetaModels/FrontendIntegration/HybridList.php
+++ b/src/MetaModels/FrontendIntegration/HybridList.php
@@ -70,7 +70,7 @@ class HybridList extends MetaModelHybrid
             $varValue = \Input::get($strName);
 
             if (is_string($varValue)) {
-                $arrReturn[$strName] = $varValue;
+                $arrReturn[$strName] = urldecode($varValue);
             }
         }
 


### PR DESCRIPTION
This makes whitespaces and special characters in URL Filter parameters possible.