### PR TITLE
Patch filter specialchars

### DIFF
--- a/src/MetaModels/Filter/Setting/Simple.php
+++ b/src/MetaModels/Filter/Setting/Simple.php
@@ -367,6 +367,10 @@ abstract class Simple implements ISimple
             return array();
         }
 
+    // remap (-slash- => /) and (-apos- => ')
+	foreach ($arrFilterUrl as $key => $value)
+		$arrFilterUrl[$key] = str_replace(array('-slash-', '-apos-'), array('/', '\''), $value);
+
         // Determine current value.
         $arrWidget['value'] = isset($arrFilterUrl[$arrWidget['eval']['urlparam']])
             ? $arrFilterUrl[$arrWidget['eval']['urlparam']]

--- a/src/MetaModels/Filter/Setting/SimpleLookup.php
+++ b/src/MetaModels/Filter/Setting/SimpleLookup.php
@@ -115,6 +115,11 @@ class SimpleLookup extends Simple
      */
     public function prepareRules(IFilter $objFilter, $arrFilterUrl)
     {
+
+	// remap (-slash- => /) and (-apos- => ')
+	foreach ($arrFilterUrl as $key => $value)
+		$arrFilterUrl[$key] = str_replace(array('-slash-', '-apos-'), array('/', '\''), $value);
+
         $objMetaModel = $this->getMetaModel();
         $objAttribute = $objMetaModel->getAttributeById($this->get('attr_id'));
         $strParam     = $this->getParamName();
@@ -134,15 +139,18 @@ class SimpleLookup extends Simple
                 }
                 $objFilterRule = new FilterRuleSimpleLookup($objAttribute, $arrFilterValue, $arrLanguages);
                 $objFilter->addFilterRule($objFilterRule);
+
                 return;
             }
 
             // We found an attribute but no match in URL. So ignore this filter setting if allow_empty is set.
             if ($this->allowEmpty()) {
+
                 $objFilter->addFilterRule(new FilterRuleStaticIdList(null));
                 return;
             }
         }
+
         // Either no attribute found or no match in url, do not return anything.
         $objFilter->addFilterRule(new FilterRuleStaticIdList(array()));
     }


### PR DESCRIPTION
the specialchars / and ' where hardcoded in -slash- and -apos-
(see ./core/src/MetaModels/FrontendIntegration/FrontendFilter.php:107)

so that the filter is working properly we should remap to the origin chars. 
