### PR TITLE
Fix copy of metamodels

### DIFF
--- a/src/MetaModels/DcGeneral/Data/Driver.php
+++ b/src/MetaModels/DcGeneral/Data/Driver.php
@@ -12,6 +12,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Christopher Bölter <c.boelter@cogizz.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource

--- a/src/MetaModels/DcGeneral/Data/Driver.php
+++ b/src/MetaModels/DcGeneral/Data/Driver.php
@@ -515,9 +515,11 @@ class Driver implements MultiLanguageDataProviderInterface
                 ->prepareFilter(
                     $this->getEmptyConfig()->setFilter(
                         array(
-                            'operation' => '=',
-                            'property' => $attribute->getColName(),
-                            'value' => $varNew
+                            array(
+                                'operation' => '=',
+                                'property' => $attribute->getColName(),
+                                'value' => $varNew
+                            )
                         )
                     )
                 )

--- a/src/MetaModels/DcGeneral/Events/MetaModel/PasteButton.php
+++ b/src/MetaModels/DcGeneral/Events/MetaModel/PasteButton.php
@@ -11,6 +11,7 @@
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource

--- a/src/MetaModels/DcGeneral/Events/MetaModel/PasteButton.php
+++ b/src/MetaModels/DcGeneral/Events/MetaModel/PasteButton.php
@@ -170,6 +170,7 @@ class PasteButton extends BaseSubscriber
             return;
         }
 
+        $this->checkForAction($clipboard, 'copy');
         $this->checkForAction($clipboard, 'create');
         $this->checkForAction($clipboard, 'cut');
 
@@ -203,6 +204,7 @@ class PasteButton extends BaseSubscriber
             return;
         }
 
+        $this->checkForAction($clipboard, 'copy');
         $this->checkForAction($clipboard, 'create');
         $this->checkForAction($clipboard, 'cut');
 


### PR DESCRIPTION
This pull request provides a solution for the missing copy feature metamodels (see #743). 

The "paste into top" feature is still missing but that's probably an issue of the dcg.