### PR TITLE
Fix sorting of metamodels.

### DIFF
--- a/contao/dca/tl_metamodel.php
+++ b/contao/dca/tl_metamodel.php
@@ -42,7 +42,7 @@ $GLOBALS['TL_DCA']['tl_metamodel'] = array
         'sorting'           => array
         (
             'mode'        => 2,
-            'fields'      => array(),
+            'fields'      => array('sorting'),
             'flag'        => 1,
             'panelLayout' => 'sort,limit'
         ),


### PR DESCRIPTION
The backend view of `tl_metamodel` can't be sorted because of the missing sorting property. This fix enables sorting after fixing contao-community-alliance/dc-general#115.