### PR TITLE
Add additional header fields by the default render setting.

### DIFF
--- a/src/MetaModels/DcGeneral/Events/MetaModel/RenderItem.php
+++ b/src/MetaModels/DcGeneral/Events/MetaModel/RenderItem.php
@@ -177,7 +177,7 @@ class RenderItem
         $additional    = array();
 
         foreach ($renderSetting->getSettingNames() as $name) {
-            $additional[$item->getAttribute($name)->get('name')] = $item->parseAttribute($name, $renderSetting)['text'];
+            $additional[$item->getAttribute($name)->getName()] = $item->parseAttribute($name, $renderSetting)['text'];
         }
 
         $additional = array_merge(

--- a/src/MetaModels/DcGeneral/Events/MetaModel/RenderItem.php
+++ b/src/MetaModels/DcGeneral/Events/MetaModel/RenderItem.php
@@ -10,6 +10,7 @@
  * @package    MetaModels
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -17,6 +18,7 @@
 
 namespace MetaModels\DcGeneral\Events\MetaModel;
 
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetParentHeaderEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\ModelToLabelEvent;
 use ContaoCommunityAlliance\DcGeneral\View\Event\RenderReadablePropertyValueEvent;
 use MetaModels\DcGeneral\Data\Model;
@@ -155,6 +157,38 @@ class RenderItem
     }
 
     /**
+     * Add additional parent header fields.
+     *
+     * @param GetParentHeaderEvent $event The subscribed event.
+     *
+     * @return void
+     */
+    public static function addAdditionalParentHeaderFields(GetParentHeaderEvent $event)
+    {
+        $parentModel = $event->getParentModel();
+
+        if (!$parentModel instanceof Model) {
+            return;
+        }
+
+        $item          = $parentModel->getItem();
+        $metaModel     = $item->getMetaModel();
+        $renderSetting = $metaModel->getServiceContainer()->getRenderSettingFactory()->createCollection($metaModel);
+        $additional    = array();
+
+        foreach ($renderSetting->getSettingNames() as $name) {
+            $additional[$item->getAttribute($name)->get('name')] = $item->parseAttribute($name, $renderSetting)['text'];
+        }
+
+        $additional = array_merge(
+            $additional,
+            $event->getAdditional()
+        );
+
+        $event->setAdditional($additional);
+    }
+
+    /**
      * Register to the event dispatcher.
      *
      * @param EventDispatcherInterface $dispatcher The event dispatcher.
@@ -165,5 +199,6 @@ class RenderItem
     {
         $dispatcher->addListener(ModelToLabelEvent::NAME, array(__CLASS__, 'render'));
         $dispatcher->addListener(RenderReadablePropertyValueEvent::NAME, array(__CLASS__, 'getReadableValue'));
+        $dispatcher->addListener(GetParentHeaderEvent::NAME, array(__CLASS__, 'addAdditionalParentHeaderFields'));
     }
 }

--- a/src/MetaModels/DcGeneral/Events/MetaModel/RenderItem.php
+++ b/src/MetaModels/DcGeneral/Events/MetaModel/RenderItem.php
@@ -177,7 +177,10 @@ class RenderItem
         $additional    = array();
 
         foreach ($renderSetting->getSettingNames() as $name) {
-            $additional[$item->getAttribute($name)->getName()] = $item->parseAttribute($name, $renderSetting)['text'];
+            $parsed = $item->parseAttribute($name, 'text', $renderSetting);
+            $name   = $item->getAttribute($name)->getName();
+
+            $additional[$name] = $parsed['text'];
         }
 
         $additional = array_merge(

--- a/src/MetaModels/DcGeneral/Events/MetaModel/RenderItem.php
+++ b/src/MetaModels/DcGeneral/Events/MetaModel/RenderItem.php
@@ -165,7 +165,7 @@ class RenderItem
      */
     public static function addAdditionalParentHeaderFields(GetParentHeaderEvent $event)
     {
-        $parentModel = $event->getParentModel();
+        $parentModel = $event->getModel();
 
         if (!$parentModel instanceof Model) {
             return;


### PR DESCRIPTION
This pull requests uses the GetParentHeaderEvent of the dc general to add additional fields based on the default render setting. Its the proposed solution for #184. 

I'm not sure if there is a better way to do it (Maybe a render setting could be chosen).

**Warning** It depends on https://github.com/contao-community-alliance/dc-general/pull/129