### PR TITLE
Disable grouping if manuals sorting is activated

### DIFF
--- a/contao/dca/tl_metamodel_dca_sortgroup.php
+++ b/contao/dca/tl_metamodel_dca_sortgroup.php
@@ -13,6 +13,7 @@
  * @author     Andreas Isaak <info@andreas-isaak.de>
  * @author     David Maack <david.maack@arcor.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -144,7 +145,6 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca_sortgroup'] = array
             'display' => array
             (
                 'ismanualsort',
-                'rendergrouptype'
             ),
         )
     ),
@@ -190,6 +190,7 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca_sortgroup'] = array
             (
                 'display after rendergrouplen' => array
                 (
+                    'rendergrouptype',
                     'rendersortattr',
                     'rendersort',
                 ),

--- a/src/MetaModels/BackendIntegration/InputScreen/InputScreenGroupingAndSorting.php
+++ b/src/MetaModels/BackendIntegration/InputScreen/InputScreenGroupingAndSorting.php
@@ -10,6 +10,7 @@
  * @package    MetaModels
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -62,6 +63,10 @@ class InputScreenGroupingAndSorting implements IInputScreenGroupingAndSorting
      */
     public function getRenderGroupType()
     {
+        if ($this->isManualSorting()) {
+            return 'none';
+        }
+
         return $this->data['rendergrouptype'];
     }
 


### PR DESCRIPTION
As explained here in contao-community-alliance/dc-general#73 the grouping won't work in combination with manual sorting. This is due to the fact that MetaModels only allow sorting by one attribute.

This pull request prepares the user interface by hiding grouping option if manual sorting is activated and by disabling the grouping in the inputscreen definition.