### PR TITLE
Followup #827: Fix/port list view header

### DIFF
--- a/src/MetaModels/DcGeneral/Dca/Builder/Builder.php
+++ b/src/MetaModels/DcGeneral/Dca/Builder/Builder.php
@@ -942,6 +942,9 @@ class Builder
             $listing->setRootIcon($icon);
         }
 
+        $this->parseListSorting($listing);
+        $this->parseListLabel($container, $listing);
+
         if ($inputScreen = $this->getInputScreenDetails()) {
             $listing->setShowColumns($inputScreen->isShowColumns());
             $renderSetting = $this->serviceContainer->getService('metamodels-view-combinations')->getRenderSetting($container->getName());
@@ -949,10 +952,8 @@ class Builder
             $metaModel = $this->serviceContainer->getFactory()->getMetaModel($container->getName());
             /** @var $renderSettingCollection \MetaModels\Render\Setting\Collection */
             $renderSettingCollection = $this->serviceContainer->getRenderSettingFactory()->createCollection($metaModel, $renderSetting);
-            $listing->setHeaderPropertyNames($renderSettingCollection->getSettingNames());
+            $listing->getLabelFormatter($container->getName())->setPropertyNames($renderSettingCollection->getSettingNames());
         }
-        $this->parseListSorting($listing);
-        $this->parseListLabel($container, $listing);
     }
 
     /**


### PR DESCRIPTION
setHeaderPropertyNames() does no longer have an effect. So we set the propertyNames in the labelFormatter