### PR TITLE
Return the sorting attribute name.

### DIFF
--- a/src/MetaModels/BackendIntegration/InputScreen/InputScreenGroupingAndSorting.php
+++ b/src/MetaModels/BackendIntegration/InputScreen/InputScreenGroupingAndSorting.php
@@ -114,7 +114,7 @@ class InputScreenGroupingAndSorting implements IInputScreenGroupingAndSorting
             if ($metaModel) {
                 $attribute = $metaModel->getAttributeById($this->data['rendersortattr']);
                 if ($attribute) {
-                    $attribute->getColName();
+                    return $attribute->getColName();
                 }
             }
         }


### PR DESCRIPTION
This fixes the left sorting issue mentioned in https://github.com/contao-community-alliance/dc-general/issues/154#issuecomment-129916954.