### PR TITLE
Pass variant base when saving an attribute.

### DIFF
--- a/src/MetaModels/MetaModel.php
+++ b/src/MetaModels/MetaModel.php
@@ -899,24 +899,17 @@ class MetaModel implements IMetaModel
     /**
      * Update the variants with the value if needed.
      *
-     * @param IItem      $item           The item to save.
+     * @param IItem  $item           The item to save.
      *
-     * @param string     $activeLanguage The language the values are in.
+     * @param string $activeLanguage The language the values are in.
      *
-     * @param int[]      $allIds         The ids of all variants.
-     *
-     * @param IItem|null $objBase        The base object for variants.
+     * @param int[]  $allIds         The ids of all variants.
      *
      * @return void
      */
-    protected function updateVariants($item, $activeLanguage, $allIds, $objBase = null)
+    protected function updateVariants($item, $activeLanguage, $allIds)
     {
         foreach ($this->getAttributes() as $strAttributeId => $objAttribute) {
-            if ($item->isVariant() && !$objBase) {
-                // Base not passed, skip attribute.
-                continue;
-            }
-
             if ($item->isVariantBase() && !($objAttribute->get('isvariant'))) {
                 // We have to override in variants.
                 $arrIds = $allIds;
@@ -1003,13 +996,7 @@ class MetaModel implements IMetaModel
             }
         }
 
-        // Fetch the base when handling an variant.
-        $objBase = null;
-        if ($objItem->isVariant()) {
-            $objBase = $this->findById($objItem->get('vargroup'));
-        }
-
-        $this->updateVariants($objItem, $strActiveLanguage, $arrAllIds, $objBase);
+        $this->updateVariants($objItem, $strActiveLanguage, $arrAllIds);
 
         // Tell all attributes that the model has been saved. Useful for alias fields, edit counters etc.
         foreach ($this->getAttributes() as $objAttribute) {

--- a/src/MetaModels/MetaModel.php
+++ b/src/MetaModels/MetaModel.php
@@ -905,11 +905,18 @@ class MetaModel implements IMetaModel
      *
      * @param int[]  $allIds         The ids of all variants.
      *
+     * @param bool   $baseAttributes If also the base attributes get updated as well.
+     *
      * @return void
      */
-    protected function updateVariants($item, $activeLanguage, $allIds)
+    protected function updateVariants($item, $activeLanguage, $allIds, $baseAttributes = false)
     {
         foreach ($this->getAttributes() as $strAttributeId => $objAttribute) {
+            if ($item->isVariant() && !($objAttribute->get('isvariant')) && !$baseAttributes) {
+                // Skip base attribute.
+                continue;
+            }
+
             if ($item->isVariantBase() && !($objAttribute->get('isvariant'))) {
                 // We have to override in variants.
                 $arrIds = $allIds;
@@ -967,8 +974,10 @@ class MetaModel implements IMetaModel
      */
     public function saveItem($objItem)
     {
+        $baseAttributes = false;
         $objItem->set('tstamp', time());
         if (!$objItem->get('id')) {
+            $baseAttributes = true;
             $this->createNewItem($objItem);
         }
 
@@ -996,7 +1005,7 @@ class MetaModel implements IMetaModel
             }
         }
 
-        $this->updateVariants($objItem, $strActiveLanguage, $arrAllIds);
+        $this->updateVariants($objItem, $strActiveLanguage, $arrAllIds, $baseAttributes);
 
         // Tell all attributes that the model has been saved. Useful for alias fields, edit counters etc.
         foreach ($this->getAttributes() as $objAttribute) {

--- a/src/MetaModels/MetaModel.php
+++ b/src/MetaModels/MetaModel.php
@@ -18,6 +18,7 @@
  * @author     David Maack <david.maack@arcor.de>
  * @author     Martin Treml <github@r2pi.net>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  2012-2015 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -898,19 +899,21 @@ class MetaModel implements IMetaModel
     /**
      * Update the variants with the value if needed.
      *
-     * @param IItem  $item           The item to save.
+     * @param IItem      $item           The item to save.
      *
-     * @param string $activeLanguage The language the values are in.
+     * @param string     $activeLanguage The language the values are in.
      *
-     * @param int[]  $allIds         The ids of all variants.
+     * @param int[]      $allIds         The ids of all variants.
+     *
+     * @param IItem|null $objBase        The base object for variants.
      *
      * @return void
      */
-    protected function updateVariants($item, $activeLanguage, $allIds)
+    protected function updateVariants($item, $activeLanguage, $allIds, $objBase = null)
     {
         foreach ($this->getAttributes() as $strAttributeId => $objAttribute) {
-            if ($item->isVariant() && !($objAttribute->get('isvariant'))) {
-                // Base not found, skip attribute.
+            if ($item->isVariant() && !$objBase) {
+                // Base not passed, skip attribute.
                 continue;
             }
 
@@ -1000,7 +1003,13 @@ class MetaModel implements IMetaModel
             }
         }
 
-        $this->updateVariants($objItem, $strActiveLanguage, $arrAllIds);
+        // Fetch the base when handling an variant.
+        $objBase = null;
+        if ($objItem->isVariant()) {
+            $objBase = $this->findById($objItem->get('vargroup'));
+        }
+
+        $this->updateVariants($objItem, $strActiveLanguage, $arrAllIds, $objBase);
 
         // Tell all attributes that the model has been saved. Useful for alias fields, edit counters etc.
         foreach ($this->getAttributes() as $objAttribute) {


### PR DESCRIPTION
This pull request provides a fix for #871. Non variant field were exlcluded when updating an variant. This leads to an issue when cloning variants because the base values will get lost. Instead of excluding them they are always refreshed from the base which shouldn't hurt.