### PR TITLE
Update MetaModel.php

### DIFF
--- a/src/MetaModels/MetaModel.php
+++ b/src/MetaModels/MetaModel.php
@@ -593,7 +593,7 @@ class MetaModel implements IMetaModel
      */
     public function getActiveLanguage()
     {
-        return $GLOBALS['TL_LANGUAGE'];
+        return array_shift(explode('-', $GLOBALS['TL_LANGUAGE']));
     }
 
     /**


### PR DESCRIPTION
Graceful degradation of MetaModels not supporting extended Locales yet. This allows the usage of extended Locales for Contao Root Pages and still displaying MetaModels in the correct language. Current state will not retrieve any instances.