### PR TITLE
Hotfix add language sort override to tl content

### DIFF
--- a/contao/languages/en/tl_content.php
+++ b/contao/languages/en/tl_content.php
@@ -13,6 +13,7 @@
  * @package    MetaModels
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Ingolf Steinhardt <info@e-spin.de> 
  * @copyright  2012-2015 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource

--- a/contao/languages/en/tl_content.php
+++ b/contao/languages/en/tl_content.php
@@ -41,6 +41,7 @@ $GLOBALS['TL_LANG']['tl_content']['metamodel_offset']               = array('Lis
 $GLOBALS['TL_LANG']['tl_content']['metamodel_limit']                = array('Maximum number of items', 'Please enter the maximum number of items. Enter 0 to show all items and therefore disable the pagination.');
 $GLOBALS['TL_LANG']['tl_content']['metamodel_sortby']               = array('Order by', 'Please choose the sort order.');
 $GLOBALS['TL_LANG']['tl_content']['metamodel_sortby_direction']     = array('Order by direction', 'Ascending or descending order.');
+$GLOBALS['TL_LANG']['tl_content']['metamodel_sort_override']        = array('Allow sort override', 'If checked, the sorting attribute and direction may be overridden via get parameter.');
 $GLOBALS['TL_LANG']['tl_content']['metamodel_filtering']            = array('Filter settings to apply', 'Select the filter settings that shall get applied when compiling the list.');
 $GLOBALS['TL_LANG']['tl_content']['metamodel_layout']               = array('Custom template to use for generating', 'Select the template that shall be used for the selected attribute. Valid template filenames start with "ce_metamodel".');
 $GLOBALS['TL_LANG']['tl_content']['metamodel_rendersettings']       = array('Render settings to apply', 'Select the rendering settings to use for generating the output. If left empty, the default settings for the selected MetaModel will get applied. If no default has been defined, the output will only get the raw values.');


### PR DESCRIPTION
## Description

add language node "sort override" at tl_content

## Checklist

- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues