### PR TITLE
Hotfix #965 fix the moving of the icons on top

### DIFF
--- a/src/MetaModels/BackendIntegration/BackendModuleBuilder.php
+++ b/src/MetaModels/BackendIntegration/BackendModuleBuilder.php
@@ -313,6 +313,24 @@ class BackendModuleBuilder
     }
 
     /**
+     * Merge two arrays recusive with unique values.
+     *
+     * @return array
+     */
+    private function array_merge_recursive_unique($array1, $array2) {
+        if (empty($array1)) return $array2;
+      
+        foreach ($array2 as $key => $value) {
+            if (is_array($value) && is_array(@$array1[$key])) {
+                $value = $this->array_merge_recursive_unique($array1[$key], $value);
+            }
+            $array1[$key] = $value;
+        }
+        
+        return $array1;
+    }
+
+    /**
      * Set the local data into the GLOBALS config.
      *
      * @return void
@@ -327,10 +345,16 @@ class BackendModuleBuilder
             if (!isset($GLOBALS['BE_MOD'][$section])) {
                 $GLOBALS['BE_MOD'][$section] = array();
             }
-
-            $GLOBALS['BE_MOD'][$section] = array_merge_recursive($GLOBALS['BE_MOD'][$section], $entries);
+            
+            foreach ($entries as $entryName => $entry) {
+                if(!isset($GLOBALS['BE_MOD'][$section][$entryName])) {
+                    $GLOBALS['BE_MOD'][$section][$entryName] = array();
+                }
+                $GLOBALS['BE_MOD'][$section][$entryName] = $this->array_merge_recursive_unique($entry, $GLOBALS['BE_MOD'][$section][$entryName]);
+            }
+            
         }
 
-        $GLOBALS['TL_LANG'] = array_merge_recursive($this->languageStrings, $GLOBALS['TL_LANG']);
+        $GLOBALS['TL_LANG'] = $this->array_merge_recursive_unique($this->languageStrings, $GLOBALS['TL_LANG']);
     }
 }

--- a/src/MetaModels/BackendIntegration/BackendModuleBuilder.php
+++ b/src/MetaModels/BackendIntegration/BackendModuleBuilder.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2015 The MetaModels team.
+ * (c) 2012-2016 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    MetaModels
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  2012-2015 The MetaModels team.
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2012-2016 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -327,7 +328,7 @@ class BackendModuleBuilder
                 $GLOBALS['BE_MOD'][$section] = array();
             }
 
-            $GLOBALS['BE_MOD'][$section] = array_merge_recursive($entries, $GLOBALS['BE_MOD'][$section]);
+            $GLOBALS['BE_MOD'][$section] = array_merge_recursive($GLOBALS['BE_MOD'][$section], $entries);
         }
 
         $GLOBALS['TL_LANG'] = array_merge_recursive($this->languageStrings, $GLOBALS['TL_LANG']);


### PR DESCRIPTION
## Description

Hotfix #965 fix the moving of the icons of the first instead of the navigation

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues

## Screenshot

current
![shot163](https://cloud.githubusercontent.com/assets/1045318/13872740/cbdf4dbe-ecec-11e5-8d59-7b65574a0654.jpg)

with hotfix
... with child table
![shot164](https://cloud.githubusercontent.com/assets/1045318/13872759/e4ce54e6-ecec-11e5-8097-3e066c7d86ba.jpg)

... with BE integration
![shot165](https://cloud.githubusercontent.com/assets/1045318/13872777/06bd3e46-eced-11e5-96ed-a3d7f1792c31.jpg)

... with DCA-Config ```dcaconfig.php```

```
<?php

/* change label  */
$GLOBALS['TL_LANG']['MOD']['metamodel_mm_mitarbeiterliste'] = array('MA (DCA-Anpassung)', 'MM Test.');

/* on top */
$GLOBALS['BE_MOD']['content'] = array_merge(
  array('metamodel_mm_mitarbeiterliste' => array(
      'tables' => array('mm_mitarbeiterliste'),
      'icon' => 'files/metamodels/icons/accept.png'
  )),
  $GLOBALS['BE_MOD']['content']  
);
```

![shot167](https://cloud.githubusercontent.com/assets/1045318/13883991/2a9c6b18-ed2c-11e5-8f4b-534d393cd1e7.jpg)
