### PR TITLE
remove child table configuration. It dosen´t really use

### DIFF
--- a/contao/dca/tl_metamodel.php
+++ b/contao/dca/tl_metamodel.php
@@ -18,6 +18,7 @@
  * @author     David Maack <david.maack@arcor.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Tim Becker <please.tim@metamodel.me>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
  * @copyright  2012-2015 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -30,17 +31,323 @@ $GLOBALS['TL_DCA']['tl_metamodel'] = array
     'config'          => array
     (
         'dataContainer'    => 'General',
-        'ctable'           => array
-        (
-            'tl_metamodel_attribute',
-            'tl_metamodel_filter',
-            'tl_metamodel_rendersettings',
-            'tl_metamodel_dca',
-            'tl_metamodel_searchable_pages',
-            'tl_metamodel_dca_combine'
-        ),
         'switchToEdit'     => true,
         'enableVersioning' => false,
+    ),
+    'dca_config' => array
+    (
+        'data_provider' => array
+        (
+            'default' => array
+            (
+                'source' => 'tl_metamodel'
+            ),
+
+            'tl_metamodel_attribute' => array
+            (
+                'source' => 'tl_metamodel_attribute'
+            ),
+
+            'tl_metamodel_rendersettings' => array
+            (
+                'source' => 'tl_metamodel_rendersettings'
+            ),
+            'tl_metamodel_rendersetting' => array
+            (
+                'source' => 'tl_metamodel_rendersetting'
+            ),
+
+            'tl_metamodel_dca' => array
+            (
+                'source' => 'tl_metamodel_dca'
+            ),
+            'tl_metamodel_dca_sortgroup' => array
+            (
+                'source' => 'tl_metamodel_dca_sortgroup'
+            ),
+            'tl_metamodel_dcasetting' => array
+            (
+                'source' => 'tl_metamodel_dcasetting'
+            ),
+
+            'tl_metamodel_searchable_pages' => array
+            (
+                'source' => 'tl_metamodel_searchable_pages'
+            ),
+
+            'tl_metamodel_filter' => array
+            (
+                'source' => 'tl_metamodel_filter'
+            ),
+            'tl_metamodel_filtersetting' => array
+            (
+                'source' => 'tl_metamodel_filtersetting'
+            ),
+
+            'tl_metamodel_dca_combine' => array
+            (
+                'source' => 'tl_metamodel_dca_combine'
+            ),
+        ),
+        'childCondition' => array
+        (
+            array
+            (
+                'from'    => 'tl_metamodel',
+                'to'      => 'tl_metamodel_attribute',
+                'setOn'   => array
+                (
+                    array
+                    (
+                        'to_field'   => 'pid',
+                        'from_field' => 'id',
+                    ),
+                ),
+                'filter'  => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                ),
+                'inverse' => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                )
+            ),
+
+            array(
+                'from'    => 'tl_metamodel',
+                'to'      => 'tl_metamodel_rendersettings',
+                'setOn'   => array
+                (
+                    array(
+                        'to_field'   => 'pid',
+                        'from_field' => 'id',
+                    ),
+                ),
+                'filter'  => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                ),
+                'inverse' => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                )
+            ),
+            array(
+                'from'   => 'tl_metamodel_rendersettings',
+                'to'     => 'tl_metamodel_rendersetting',
+                'setOn'  => array
+                (
+                    array
+                    (
+                        'to_field'   => 'pid',
+                        'from_field' => 'id',
+                    ),
+                ),
+                'filter' => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                )
+            ),
+
+            array
+            (
+                'from'    => 'tl_metamodel',
+                'to'      => 'tl_metamodel_dca',
+                'setOn'   => array
+                (
+                    array
+                    (
+                        'to_field'   => 'pid',
+                        'from_field' => 'id',
+                    ),
+                ),
+                'filter'  => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                ),
+                'inverse' => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                )
+            ),array
+            (
+                'from'    => 'tl_metamodel_dca',
+                'to'      => 'tl_metamodel_dca_sortgroup',
+                'setOn'   => array
+                (
+                    array
+                    (
+                        'to_field'   => 'pid',
+                        'from_field' => 'id',
+                    ),
+                ),
+                'filter'  => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                ),
+            ),
+            array
+            (
+                'from'   => 'tl_metamodel_dca',
+                'to'     => 'tl_metamodel_dcasetting',
+                'setOn'  => array
+                (
+                    array
+                    (
+                        'to_field'   => 'pid',
+                        'from_field' => 'id',
+                    ),
+                ),
+                'filter' => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                )
+            ),
+
+            array
+            (
+                'from'                => 'tl_metamodel',
+                'to'                  => 'tl_metamodel_searchable_pages',
+                'setOn'               => array
+                (
+                    array
+                    (
+                        'to_field'    => 'pid',
+                        'from_field'  => 'id',
+                    ),
+                ),
+                'filter'              => array
+                (
+                    array
+                    (
+                        'local'       => 'pid',
+                        'remote'      => 'id',
+                        'operation'   => '=',
+                    ),
+                ),
+                'inverse' => array
+                (
+                    array
+                    (
+                        'local' => 'pid',
+                        'remote' => 'id',
+                        'operation' => '=',
+                    ),
+                )
+            ),
+
+            array
+            (
+                'from'                => 'tl_metamodel',
+                'to'                  => 'tl_metamodel_filter',
+                'setOn'               => array
+                (
+                    array
+                    (
+                        'to_field'    => 'pid',
+                        'from_field'  => 'id',
+                    ),
+                ),
+                'filter'              => array
+                (
+                    array
+                    (
+                        'local'       => 'pid',
+                        'remote'      => 'id',
+                        'operation'   => '=',
+                    ),
+                ),
+            ),
+            array(
+                'from'   => 'tl_metamodel_filter',
+                'to'     => 'tl_metamodel_filtersetting',
+                'setOn'  => array
+                (
+                    array
+                    (
+                        'to_field'   => 'fid',
+                        'from_field' => 'id',
+                    )
+                ),
+                'filter' => array
+                (
+                    array
+                    (
+                        'local'     => 'fid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                )
+            ),
+
+            array
+            (
+                'from'                => 'tl_metamodel',
+                'to'                  => 'tl_metamodel_dca_combine',
+                'setOn'               => array
+                (
+                    array
+                    (
+                        'to_field'    => 'pid',
+                        'from_field'  => 'id',
+                    ),
+                ),
+                'filter'              => array
+                (
+                    array
+                    (
+                        'local'       => 'pid',
+                        'remote'      => 'id',
+                        'operation'   => '=',
+                    ),
+                ),
+            ),
+        ),
     ),
     'list'            => array
     (

--- a/contao/dca/tl_metamodel_dca.php
+++ b/contao/dca/tl_metamodel_dca.php
@@ -18,6 +18,7 @@
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Tim Becker <tim@westwerk.ac>
  * @author     Alexander Menk <a.menk@imi.de>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
  * @copyright  2012-2015 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -29,7 +30,6 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
     (
         'dataContainer'    => 'General',
         'ptable'           => 'tl_metamodel',
-        'ctable'           => 'tl_metamodel_dcasetting',
         'switchToEdit'     => false,
         'enableVersioning' => false,
     ),
@@ -37,14 +37,22 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
     (
         'data_provider'  => array
         (
-            'default' => array
+            'default'                    => array
             (
                 'source' => 'tl_metamodel_dca'
             ),
-            'parent'  => array
+            'parent'                     => array
             (
                 'source' => 'tl_metamodel'
-            )
+            ),
+            'tl_metamodel_dca_sortgroup' => array
+            (
+                'source' => 'tl_metamodel_dca_sortgroup'
+            ),
+            'tl_metamodel_dcasetting'    => array
+            (
+                'source' => 'tl_metamodel_dcasetting'
+            ),
         ),
         'childCondition' => array
         (
@@ -78,7 +86,53 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
                         'operation' => '=',
                     ),
                 )
-            )
+            ),
+
+            array
+            (
+                'from'   => 'tl_metamodel_dca',
+                'to'     => 'tl_metamodel_dca_sortgroup',
+                'setOn'  => array
+                (
+                    array
+                    (
+                        'to_field'   => 'pid',
+                        'from_field' => 'id',
+                    ),
+                ),
+                'filter' => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                ),
+            ),
+
+            array
+            (
+                'from'   => 'tl_metamodel_dca',
+                'to'     => 'tl_metamodel_dcasetting',
+                'setOn'  => array
+                (
+                    array
+                    (
+                        'to_field'   => 'pid',
+                        'from_field' => 'id',
+                    ),
+                ),
+                'filter' => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                )
+            ),
         ),
     ),
     'list'                  => array
@@ -108,19 +162,19 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
         ),
         'operations'        => array
         (
-            'edit'     => array
+            'edit'               => array
             (
                 'label' => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['edit'],
                 'href'  => 'act=edit',
                 'icon'  => 'edit.gif',
             ),
-            'copy'     => array
+            'copy'               => array
             (
                 'label' => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['copy'],
                 'href'  => 'act=copy',
                 'icon'  => 'copy.gif',
             ),
-            'delete'   => array
+            'delete'             => array
             (
                 'label'      => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['delete'],
                 'href'       => 'act=delete',
@@ -130,7 +184,7 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
                     $GLOBALS['TL_LANG']['MSC']['deleteConfirm']
                 )
             ),
-            'show'     => array
+            'show'               => array
             (
                 'label' => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['show'],
                 'href'  => 'act=show',
@@ -143,7 +197,7 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
                 'icon'    => 'system/modules/metamodels/assets/images/icons/dca_groupsortsettings.png',
                 'idparam' => 'pid'
             ),
-            'settings' => array
+            'settings'           => array
             (
                 'label'   => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['settings'],
                 'href'    => 'table=tl_metamodel_dcasetting',
@@ -152,26 +206,26 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
             ),
         )
     ),
-    'metapalettes' => array
+    'metapalettes'          => array
     (
         'default' => array
         (
-            'title' => array
+            'title'       => array
             (
                 'name',
                 'isdefault'
             ),
-            'view' => array
+            'view'        => array
             (
                 'panelLayout',
             ),
-            'backend' => array
+            'backend'     => array
             (
                 'rendertype',
                 'backendcaption',
                 'backendicon',
             ),
-            'display' => array
+            'display'     => array
             (
                 'rendermode',
                 'showColumns'
@@ -192,14 +246,14 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
             (
                 'backend after rendertype' => array('backendsection'),
             ),
-            'ctable' => array
+            'ctable'     => array
             (
                 'backend after rendertype' => array('ptable'),
             )
         ),
         'rendermode' => array
         (
-            'flat' => array
+            'flat'     => array
             (
                 'display after rendermode' => array(),
             ),
@@ -258,24 +312,24 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
                 'includeBlankOption' => true
             )
         ),
-        'rendermode' => array
+        'rendermode'     => array
         (
-            'label'                   => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['rendermode'],
-            'inputType'               => 'select',
-            'eval'                    => array
+            'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['rendermode'],
+            'inputType' => 'select',
+            'eval'      => array
             (
-                'tl_class'            => 'w50',
-                'submitOnChange'      => true
+                'tl_class'       => 'w50',
+                'submitOnChange' => true
             )
         ),
-        'showColumns' => array
+        'showColumns'    => array
         (
-            'label'                   => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['showColumns'],
-            'inputType'               => 'checkbox',
-            'eval'                    => array
+            'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['showColumns'],
+            'inputType' => 'checkbox',
+            'eval'      => array
             (
-                'tl_class'            => 'w50',
-                'submitOnChange'      => true
+                'tl_class'       => 'w50',
+                'submitOnChange' => true
             )
         ),
         'backendsection' => array
@@ -321,10 +375,15 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
                         'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['becap_langcode'],
                         'exclude'   => true,
                         'inputType' => 'select',
-                        'options'   => array_flip(array_filter(array_flip($this->getLanguages()), function ($langCode) {
-                            // Disable >2 char long language codes for the moment.
-                            return (strlen($langCode) == 2);
-                        })),
+                        'options'   => array_flip(
+                            array_filter(
+                                array_flip($this->getLanguages()),
+                                function ($langCode) {
+                                    // Disable >2 char long language codes for the moment.
+                                    return (strlen($langCode) == 2);
+                                }
+                            )
+                        ),
                         'eval'      => array
                         (
                             'tl_class' => 'clr',
@@ -365,31 +424,31 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
                 'tl_class' => 'clr long wizard',
             ),
         ),
-        'iseditable' => array
+        'iseditable'     => array
         (
-            'label'                   => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['iseditable'],
-            'inputType'               => 'checkbox',
-            'eval'                    => array
+            'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['iseditable'],
+            'inputType' => 'checkbox',
+            'eval'      => array
             (
-                'tl_class'            => 'w50 m12 cbx',
+                'tl_class' => 'w50 m12 cbx',
             )
         ),
-        'iscreatable' => array
+        'iscreatable'    => array
         (
-            'label'                   => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['iscreatable'],
-            'inputType'               => 'checkbox',
-            'eval'                    => array
+            'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['iscreatable'],
+            'inputType' => 'checkbox',
+            'eval'      => array
             (
-                'tl_class'            => 'w50 m12 cbx',
+                'tl_class' => 'w50 m12 cbx',
             )
         ),
-        'isdeleteable' => array
+        'isdeleteable'   => array
         (
-            'label'                   => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['isdeleteable'],
-            'inputType'               => 'checkbox',
-            'eval'                    => array
+            'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['isdeleteable'],
+            'inputType' => 'checkbox',
+            'eval'      => array
             (
-                'tl_class'            => 'w50 m12 cbx',
+                'tl_class' => 'w50 m12 cbx',
             )
         )
     )

--- a/contao/dca/tl_metamodel_rendersettings.php
+++ b/contao/dca/tl_metamodel_rendersettings.php
@@ -18,6 +18,7 @@
  * @author     Oliver Hoff <oliver@hofff.com>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Alexander Menk <a.menk@imi.de>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
  * @copyright  2012-2015 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -29,7 +30,6 @@ $GLOBALS['TL_DCA']['tl_metamodel_rendersettings'] = array
     (
         'dataContainer'    => 'General',
         'ptable'           => 'tl_metamodel',
-        'ctable'           => 'tl_metamodel_rendersetting',
         'switchToEdit'     => false,
         'enableVersioning' => false,
     ),
@@ -37,10 +37,14 @@ $GLOBALS['TL_DCA']['tl_metamodel_rendersettings'] = array
     (
         'data_provider'  => array
         (
-            'parent' => array
+            'parent'                     => array
             (
                 'source' => 'tl_metamodel'
-            )
+            ),
+            'tl_metamodel_rendersetting' => array
+            (
+                'source' => 'tl_metamodel_rendersetting'
+            ),
         ),
         'childCondition' => array
         (
@@ -72,7 +76,29 @@ $GLOBALS['TL_DCA']['tl_metamodel_rendersettings'] = array
                         'operation' => '=',
                     ),
                 )
-            )
+            ),
+
+            array(
+                'from'   => 'tl_metamodel_rendersettings',
+                'to'     => 'tl_metamodel_rendersetting',
+                'setOn'  => array
+                (
+                    array
+                    (
+                        'to_field'   => 'pid',
+                        'from_field' => 'id',
+                    ),
+                ),
+                'filter' => array
+                (
+                    array
+                    (
+                        'local'     => 'pid',
+                        'remote'    => 'id',
+                        'operation' => '=',
+                    ),
+                )
+            ),
         ),
         'child_list'     => array
         (


### PR DESCRIPTION
After use the feature delete deep.
https://github.com/MetaModels/core/pull/998

Can you use this pull request. The child table configuration removed, by the data container.

Testing in Backend mode true.
Maybe this configuration used in Frontend mode.