### PR TITLE
isVariant() did not work properly after varCopy() (see #897)

### DIFF
--- a/src/MetaModels/Item.php
+++ b/src/MetaModels/Item.php
@@ -487,10 +487,10 @@ class Item implements IItem
         // If this item is a variant base, we need to clean the variant base and set ourselves as the base.
         if ($this->isVariantBase()) {
             $objNewItem->set('vargroup', $this->get('id'));
-            $objNewItem->set('varbase', 0);
+            $objNewItem->set('varbase', '0');
         } else {
             $objNewItem->set('vargroup', $this->get('vargroup'));
-            $objNewItem->set('varbase', 0);
+            $objNewItem->set('varbase', '0');
         }
         return $objNewItem;
     }


### PR DESCRIPTION
## Description

Discussion see #897
Alternatively we can adjust the ```isVariant()``` and ```isVariantBase()``` performing a not-identical but equal check.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
