### PR TITLE
Hotfix to afford special characters at FE search and filtering e.g. +, /. %ef

### DIFF
--- a/src/MetaModels/FrontendIntegration/FrontendFilter.php
+++ b/src/MetaModels/FrontendIntegration/FrontendFilter.php
@@ -114,8 +114,8 @@ class FrontendFilter
                 $strFilterAction .= sprintf(
                     $GLOBALS['TL_CONFIG']['disableAlias'] ? '&amp;%s=%s' : '/%s/%s',
                     $strName,
-                    // double rawurlencode to encode all special characters
-                    // look at http://php.net/manual/en/function.rawurlencode.php
+                    // Double rawurlencode to encode all special characters.
+                    // Look at http://php.net/manual/en/function.rawurlencode.php .
                     rawurlencode(rawurlencode($strValue))
                 );
             }

--- a/src/MetaModels/FrontendIntegration/FrontendFilter.php
+++ b/src/MetaModels/FrontendIntegration/FrontendFilter.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2015 The MetaModels team.
+ * (c) 2012-2016 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,7 +16,8 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Christopher Boelter <christopher@boelter.eu>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
- * @copyright  2012-2015 The MetaModels team.
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2012-2016 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -113,7 +114,9 @@ class FrontendFilter
                 $strFilterAction .= sprintf(
                     $GLOBALS['TL_CONFIG']['disableAlias'] ? '&amp;%s=%s' : '/%s/%s',
                     $strName,
-                    rawurlencode($strValue)
+                    // double rawurlencode to encode all special characters
+                    // look at http://php.net/manual/en/function.rawurlencode.php
+                    rawurlencode(rawurlencode($strValue))
                 );
             }
         }

--- a/src/MetaModels/FrontendIntegration/HybridList.php
+++ b/src/MetaModels/FrontendIntegration/HybridList.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2015 The MetaModels team.
+ * (c) 2012-2016 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,7 +16,8 @@
  * @author     David Maack <david.maack@arcor.de>
  * @author     Oliver Hoff <oliver@hofff.com>
  * @author     Ondrej Brinkel <Sam256@web.de>
- * @copyright  2012-2015 The MetaModels team.
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2012-2016 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -70,7 +71,7 @@ class HybridList extends MetaModelHybrid
             $varValue = \Input::get($strName);
 
             if (is_string($varValue)) {
-                $arrReturn[$strName] = rawurldecode($varValue);
+                $arrReturn[$strName] = $varValue;
             }
         }
 


### PR DESCRIPTION
## Description

The PR fix to use special characters at your string to search or filter eg. +, /, %fe

look at https://github.com/MetaModels/core/issues/910

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
