### PR TITLE
Fix performance issue

### DIFF
--- a/.check-author.yml
+++ b/.check-author.yml
@@ -26,6 +26,7 @@ mapping:
   "Ingolf Steinhardt <info@e-spin.de>":
     - "xantippe <info@e-spin.de>"
     - "zonky2 <info@e-spin.de>"
+  "binron <rtb@gmx.ch>": "binron <rtb@gmx.ch>"
 
 copy-left:
   "Christoph Wiechert <christoph.wiechert@4wardmedia.de>": MetaModels/Widgets/PickerWidget.php

--- a/src/MetaModels/DcGeneral/Data/Driver.php
+++ b/src/MetaModels/DcGeneral/Data/Driver.php
@@ -254,7 +254,7 @@ class Driver implements MultiLanguageDataProviderInterface
             $modelId = reset($ids);
         }
 
-        $objItem = $modelId ? $this->getMetaModel()->findById($modelId) : null;
+        $objItem = $modelId ? $this->getMetaModel()->findById($modelId, $objConfig->getFields() ?: array()) : null;
 
         $this->setLanguage($backupLanguage);
 

--- a/src/MetaModels/DcGeneral/Data/Driver.php
+++ b/src/MetaModels/DcGeneral/Data/Driver.php
@@ -16,6 +16,7 @@
  * @author     Christopher Bölter <c.boelter@cogizz.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     binron <rtb@gmx.ch>
  * @copyright  2012-2015 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource


### PR DESCRIPTION
Add arrAttrOnly parameter to the $this->getMetaModel()->findById call
In my case it reduced the number of queries from 9005 to 382 (see Screenshots)!

IMPORTANT: https://github.com/contao-community-alliance/dc-general/pull/305
needs to be fixed first

<img width="825" alt="screen shot 2016-09-02 at 10 20 46" src="https://cloud.githubusercontent.com/assets/3243377/18197620/6d76cfb4-70f8-11e6-9c0a-292f37827b28.png">
<img width="840" alt="screen shot 2016-09-02 at 10 21 18" src="https://cloud.githubusercontent.com/assets/3243377/18197626/726fe3fc-70f8-11e6-89e6-34f7bb932097.png">
