### PR TITLE
Increase length of meta description

### DIFF
--- a/.check-author.yml
+++ b/.check-author.yml
@@ -26,6 +26,8 @@ mapping:
   "Ingolf Steinhardt <info@e-spin.de>":
     - "xantippe <info@e-spin.de>"
     - "zonky2 <info@e-spin.de>"
+  "Jeremie Constant <j.constant@imi.de>":
+    - "JeremieConstant <j.constant@imi.de>"
 
 copy-left:
   "Christoph Wiechert <christoph.wiechert@4wardmedia.de>": MetaModels/Widgets/PickerWidget.php

--- a/src/MetaModels/ItemList.php
+++ b/src/MetaModels/ItemList.php
@@ -19,6 +19,7 @@
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Tim Gatzky <info@tim-gatzky.de>
  * @author     Martin Treml <github@r2pi.net>
+ * @author     Jeremie Constant <j.constant@imi.de>
  * @copyright  2012-2015 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -772,7 +773,12 @@ class ItemList implements IServiceContainerAware
                     $arrDescription = $objCurrentItem->parseAttribute($this->strDescriptionAttribute, 'text');
 
                     if (!empty($arrDescription['text'])) {
-                        $page->description = \String::substr($arrDescription['text'], 120);
+                        // PHP 7 compatibility, see https://github.com/contao/core-bundle/issues/309
+                        if (version_compare(VERSION . '.' . BUILD, '3.5.5', '>=')) {
+                            $page->description = \StringUtil::substr($arrDescription['text'], 160);
+                        } else {
+                            $page->description = \String::substr($arrDescription['text'], 160);
+                        }
                         break;
                     }
                 }


### PR DESCRIPTION
## Description

Increase length of meta description to 160

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues

Google shows 160 characters, but metamodels are only rendering out 120.