### PR TITLE
add 'submitOnChange' => true at DCA tl_metamodel_filtersetting.php

### DIFF
--- a/contao/dca/tl_metamodel_filtersetting.php
+++ b/contao/dca/tl_metamodel_filtersetting.php
@@ -477,7 +477,8 @@ $GLOBALS['TL_DCA']['tl_metamodel_filtersetting'] = array
             'inputType' => 'checkbox',
             'eval'      => array
             (
-                'tl_class' => 'w50',
+                'tl_class'       => 'w50',
+                'submitOnChange' => true,
             ),
         ),
         'onlypossible'      => array


### PR DESCRIPTION
## Description

add 'submitOnChange' => true at DCA tl_metamodel_filtersetting.php - after change we have other values at select "Default" in filter rule "simple lookup"

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues

