### PR TITLE
Hotfix sorting for multilanguage attributes

### DIFF
--- a/src/MetaModels/Attribute/TranslatedReference.php
+++ b/src/MetaModels/Attribute/TranslatedReference.php
@@ -46,7 +46,7 @@ abstract class TranslatedReference extends BaseComplex implements ITranslated
      *
      * @return array
      */
-    protected function getWhere($mixIds, $mixLangCode = '')
+    private function getWhere($mixIds, $mixLangCode = '')
     {
         $procedure  = 'att_id=?';
         $parameters = array($this->get('id'));


### PR DESCRIPTION
## Description

The sorting at other languages as the fallback language are inconsitent.
## Checklist
- [ ] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues

@discordier: thanks for the "support" ;-)
