### PR TITLE
Hotfix #1063 set default legend name at name of metamodels

### DIFF
--- a/src/MetaModels/BackendIntegration/InputScreen/InputScreen.php
+++ b/src/MetaModels/BackendIntegration/InputScreen/InputScreen.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2015 The MetaModels team.
+ * (c) 2012-2016 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,7 +16,8 @@
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     David Molineus <david.molineus@netzmacht.de>
  * @author     Alexander Menk <a.menk@imi.de>
- * @copyright  2012-2015 The MetaModels team.
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2012-2016 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -225,7 +226,7 @@ class InputScreen implements IInputScreen
     {
         $metaModel      = $this->getMetaModel();
         $activeLegend   = $this->translateLegend(
-            array('legendtitle' => 'Unnamed legend', 'legendhide' => false),
+            array('legendtitle' => $metaModel->getName(), 'legendhide' => false),
             $metaModel
         );
         $activeLegendId = null;


### PR DESCRIPTION
## Description

Hotfix #1063 set default legend name at name of metamodels

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues

