### PR TITLE
[RTM] Do not copy column `vargroup`

### DIFF
--- a/src/MetaModels/Item.php
+++ b/src/MetaModels/Item.php
@@ -469,6 +469,7 @@ class Item implements IItem
         $arrNewData = $this->arrData;
         unset($arrNewData['id']);
         unset($arrNewData['tstamp']);
+        unset($arrNewData['vargroup']);
         return new Item($this->getMetaModel(), $arrNewData);
     }
 


### PR DESCRIPTION
## Description

Do not copy the system column `vargroup` because when doing so, the copy references to its origin which leads to data loss when editing one of these models in the back end.
The correct `vargroup` will be set in `MetaModel::createNewItem()`.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
