### PR TITLE
Remove the front end editing fragments from the core template and rework "actions" in the list template

### DIFF
--- a/contao/templates/ce_metamodel_list.html5
+++ b/contao/templates/ce_metamodel_list.html5
@@ -1,10 +1,6 @@
 <?php $this->extend($this->searchable ? 'block_searchable' : 'block_unsearchable'); ?>
 
 <?php $this->block('content'); ?>
-<?php if ($this->editEnable): ?>
-<div class="addUrl"><a href="<?= $this->addUrl ?>"><?= $this->addNewLabel ?></a></div>
-<?php endif; ?>
-
 <?= $this->items ?>
 <?= $this->pagination ?>
 <?php $this->endblock(); ?>

--- a/contao/templates/ce_metamodel_list.xhtml
+++ b/contao/templates/ce_metamodel_list.xhtml
@@ -1,10 +1,6 @@
 <?php $this->extend($this->searchable ? 'block_searchable' : 'block_unsearchable'); ?>
 
 <?php $this->block('content'); ?>
-<?php if ($this->editEnable): ?>
-<div class="addUrl"><a href="<?= $this->addUrl ?>"><?= $this->addNewLabel ?></a></div>
-<?php endif; ?>
-
 <?= $this->items ?>
 <?= $this->pagination ?>
 <?php $this->endblock(); ?>

--- a/contao/templates/metamodel_prerendered.html5
+++ b/contao/templates/metamodel_prerendered.html5
@@ -18,9 +18,11 @@
 <?php endif; ?>
 <?php endforeach; ?>
 <?php $this->block('actions'); ?>
-<?php if ($arrItem['jumpTo']['deep']): ?>
-<a href="<?= $arrItem['jumpTo']['url'] ?>"><?= $this->details ?></a>
-<?php endif; ?>
+<div class="actions">
+<?php foreach($arrItem['actions'] as $action): ?>
+<a href="<?= $action['href']; ?>"<?php if ($action['class']): ?> class="<?= $action['class']; ?>"<?php endif; ?><?php if ($action['title']): ?> title="<?= $action['title']; ?><?php endif; ?>"<?= $action['attribute']; ?>><?= $action['label']; ?></a>
+<?php endforeach; ?>
+</div>
 <?php $this->endblock(); ?>
 </div>
 <?php endforeach; ?>

--- a/contao/templates/metamodel_prerendered.html5
+++ b/contao/templates/metamodel_prerendered.html5
@@ -21,9 +21,6 @@
 <?php if ($arrItem['jumpTo']['deep']): ?>
 <a href="<?= $arrItem['jumpTo']['url'] ?>"><?= $this->details ?></a>
 <?php endif; ?>
-<?php if (isset($this->editEnable) && $this->editEnable): ?>
-<a href="<?= $arrItem['editUrl'] ?>"><?= $this->editLabel ?></a>
-<?php endif; ?>
 <?php $this->endblock(); ?>
 </div>
 <?php endforeach; ?>

--- a/contao/templates/metamodel_prerendered.html5
+++ b/contao/templates/metamodel_prerendered.html5
@@ -25,9 +25,9 @@
 </div>
 <?php $this->endblock(); ?>
 </div>
+<?php $this->endblock(); ?>
 <?php endforeach; ?>
 </div>
-<?php $this->endblock(); ?>
 <?php else : ?>
 <?php $this->block('noItem'); ?>
 <p class="info"><?= $this->noItemsMsg ?></p>

--- a/contao/templates/metamodel_prerendered.text
+++ b/contao/templates/metamodel_prerendered.text
@@ -13,8 +13,13 @@ if (count($this->data)) {
             }
         }
 
-        if ($item['jumpTo']['deep']) {
-            echo $this->details . ': ' . $item['jumpTo']['url'];
+        foreach ($item['actions'] as $action) {
+            echo sprintf(
+                '%s: %s%s',
+                $action['label'],
+                $action['href'],
+                PHP_EOL
+            );
         }
     }
 } else {

--- a/contao/templates/metamodel_prerendered.xhtml
+++ b/contao/templates/metamodel_prerendered.xhtml
@@ -18,9 +18,11 @@
 <?php endif; ?>
 <?php endforeach; ?>
 <?php $this->block('actions'); ?>
-<?php if ($arrItem['jumpTo']['deep']): ?>
-<a href="<?= $arrItem['jumpTo']['url'] ?>"><?= $this->details ?></a>
-<?php endif; ?>
+<div class="actions">
+<?php foreach($arrItem['actions'] as $action): ?>
+<a href="<?= $action['href']; ?>"<?php if ($action['class']): ?> class="<?= $action['class']; ?>"<?php endif; ?><?php if ($action['title']): ?> title="<?= $action['title']; ?><?php endif; ?>"<?= $action['attribute']; ?>><?= $action['label']; ?></a>
+<?php endforeach; ?>
+</div>
 <?php $this->endblock(); ?>
 </div>
 <?php endforeach; ?>

--- a/contao/templates/metamodel_prerendered.xhtml
+++ b/contao/templates/metamodel_prerendered.xhtml
@@ -21,9 +21,6 @@
 <?php if ($arrItem['jumpTo']['deep']): ?>
 <a href="<?= $arrItem['jumpTo']['url'] ?>"><?= $this->details ?></a>
 <?php endif; ?>
-<?php if (isset($this->editEnable) && $this->editEnable): ?>
-<a href="<?= $arrItem['editUrl'] ?>"><?= $this->editLabel ?></a>
-<?php endif; ?>
 <?php $this->endblock(); ?>
 </div>
 <?php endforeach; ?>

--- a/contao/templates/metamodel_prerendered.xhtml
+++ b/contao/templates/metamodel_prerendered.xhtml
@@ -25,9 +25,9 @@
 </div>
 <?php $this->endblock(); ?>
 </div>
+<?php $this->endblock(); ?>
 <?php endforeach; ?>
 </div>
-<?php $this->endblock(); ?>
 <?php else : ?>
 <?php $this->block('noItem'); ?>
 <p class="info"><?= $this->noItemsMsg ?></p>

--- a/contao/templates/metamodel_unrendered.html5
+++ b/contao/templates/metamodel_unrendered.html5
@@ -17,9 +17,11 @@
 <?php endif; ?>
 <?php endforeach; ?>
 <?php $this->block('actions'); ?>
-<?php if ($arrItem['jumpTo']['deep']): ?>
-<a href="<?= $arrItem['jumpTo']['url'] ?>"><?= $this->details ?></a>
-<?php endif; ?>
+<div class="actions">
+<?php foreach($arrItem['actions'] as $action): ?>
+<a href="<?= $action['href']; ?>"<?php if ($action['class']): ?> class="<?= $action['class']; ?>"<?php endif; ?><?php if ($action['title']): ?> title="<?= $action['title']; ?><?php endif; ?>"<?= $action['attribute']; ?>><?= $action['label']; ?></a>
+<?php endforeach; ?>
+</div>
 <?php $this->endblock(); ?>
 </div>
 <?php endforeach; ?>

--- a/contao/templates/metamodel_unrendered.html5
+++ b/contao/templates/metamodel_unrendered.html5
@@ -24,8 +24,8 @@
 </div>
 <?php $this->endblock(); ?>
 </div>
-<?php endforeach; ?>
 <?php $this->endblock(); ?>
+<?php endforeach; ?>
 </div>
 <?php else: ?>
 <?php $this->block('noItem'); ?>

--- a/contao/templates/metamodel_unrendered.text
+++ b/contao/templates/metamodel_unrendered.text
@@ -13,8 +13,13 @@ if ($this->items->getCount()) {
             }
         }
 
-        if ($item['jumpTo']['deep']) {
-            echo $this->details . ': ' . $item['jumpTo']['url'];
+        foreach ($item['actions'] as $action) {
+            echo sprintf(
+                '%s: %s%s',
+                $action['label'],
+                $action['href'],
+                PHP_EOL
+            );
         }
     }
 } else {

--- a/contao/templates/metamodel_unrendered.xhtml
+++ b/contao/templates/metamodel_unrendered.xhtml
@@ -17,9 +17,11 @@
 <?php endif; ?>
 <?php endforeach; ?>
 <?php $this->block('actions'); ?>
-<?php if ($arrItem['jumpTo']['deep']): ?>
-<a href="<?= $arrItem['jumpTo']['url'] ?>"><?= $this->details ?></a>
-<?php endif; ?>
+<div class="actions">
+<?php foreach($arrItem['actions'] as $action): ?>
+<a href="<?= $action['href']; ?>"<?php if ($action['class']): ?> class="<?= $action['class']; ?>"<?php endif; ?><?php if ($action['title']): ?> title="<?= $action['title']; ?><?php endif; ?>"<?= $action['attribute']; ?>><?= $action['label']; ?></a>
+<?php endforeach; ?>
+</div>
 <?php $this->endblock(); ?>
 </div>
 <?php endforeach; ?>

--- a/contao/templates/metamodel_unrendered.xhtml
+++ b/contao/templates/metamodel_unrendered.xhtml
@@ -24,8 +24,8 @@
 </div>
 <?php $this->endblock(); ?>
 </div>
-<?php endforeach; ?>
 <?php $this->endblock(); ?>
+<?php endforeach; ?>
 </div>
 <?php else: ?>
 <?php $this->block('noItem'); ?>

--- a/src/MetaModels/Item.php
+++ b/src/MetaModels/Item.php
@@ -388,14 +388,14 @@ class Item implements IItem
     {
         $this->registerAssets($objSettings);
 
-        $arrResult = array
-        (
-            'raw' => $this->arrData,
-            'text' => array(),
-            'attributes' => array(),
-            $strOutputFormat => array(),
-            'class' => ''
-        );
+        $arrResult = [
+            'raw'            => $this->arrData,
+            'text'           => [],
+            'attributes'     => [],
+            $strOutputFormat => [],
+            'class'          => '',
+            'actions'        => []
+        ];
 
         // No render settings, parse "normal" and hope the best - not all attribute types must provide usable output.
         if (!$objSettings) {
@@ -408,7 +408,18 @@ class Item implements IItem
             return $arrResult;
         }
 
-        $arrResult['jumpTo'] = $this->buildJumpToLink($objSettings);
+        // Add jumpTo link
+        $jumpTo = $this->buildJumpToLink($objSettings);
+        if (true === $jumpTo['deep']) {
+            $arrResult['actions']['jumpTo'] = [
+                'href'  => $jumpTo['url'],
+                'label' => $this->getCaptionText('details'),
+                'class' => 'details'
+            ];
+        }
+
+        // Just here for backwards compatibility with templates. See #1087
+        $arrResult['jumpTo'] = $jumpTo;
 
         // First, parse the values in the same order as they are in the render settings.
         foreach ($objSettings->getSettingNames() as $strAttrName) {
@@ -512,5 +523,38 @@ class Item implements IItem
             $objNewItem->set('varbase', '0');
         }
         return $objNewItem;
+    }
+
+
+    /**
+     * Retrieve the translation string for the given lang key.
+     *
+     * In order to achieve the correct caption text, the function tries several translation strings sequentially.
+     * The first language key that is set will win, even if it is to be considered empty.
+     *
+     * This message is looked up in the following order:
+     * 1. $GLOBALS['TL_LANG']['MSC'][<mm tablename>][<render settings id>][$langKey]
+     * 2. $GLOBALS['TL_LANG']['MSC'][<mm tablename>][$langKey]
+     * 3. $GLOBALS['TL_LANG']['MSC'][$langKey]
+     *
+     * @param string $langKey The language key to retrieve.
+     *
+     * @return string
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     * @SuppressWarnings(PHPMD.CamelCaseVariableName)
+     */
+    private function getCaptionText($langKey)
+    {
+        $tableName = $this->getMetaModel()->getTableName();
+        if (isset($this->objView)
+            && isset($GLOBALS['TL_LANG']['MSC'][$tableName][$this->objView->get('id')][$langKey])
+        ) {
+            return $GLOBALS['TL_LANG']['MSC'][$tableName][$this->objView->get('id')][$langKey];
+        } elseif (isset($GLOBALS['TL_LANG']['MSC'][$tableName][$langKey])) {
+            return $GLOBALS['TL_LANG']['MSC'][$tableName][$langKey];
+        }
+
+        return $GLOBALS['TL_LANG']['MSC'][$langKey];
     }
 }

--- a/src/MetaModels/ItemList.php
+++ b/src/MetaModels/ItemList.php
@@ -20,7 +20,8 @@
  * @author     Tim Gatzky <info@tim-gatzky.de>
  * @author     Martin Treml <github@r2pi.net>
  * @author     Jeremie Constant <j.constant@imi.de>
- * @copyright  2012-2015 The MetaModels team.
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -692,24 +693,6 @@ class ItemList implements IServiceContainerAware
     }
 
     /**
-     * Retrieve the caption text for the "Show details" link.
-     *
-     * In order to achieve the correct caption text, the function tries several translation strings sequentially.
-     * The first language key that is set will win, even if it is to be considered empty.
-     *
-     * This message is looked up in the following order:
-     * 1. $GLOBALS['TL_LANG']['MSC'][<mm tablename>][<render settings id>]['details']
-     * 2. $GLOBALS['TL_LANG']['MSC'][<mm tablename>]['details']
-     * 3. $GLOBALS['TL_LANG']['MSC']['details']
-     *
-     * @return string
-     */
-    protected function getDetailsCaption()
-    {
-        return $this->getCaptionText('details');
-    }
-
-    /**
      * Set the title and description in the page object.
      *
      * @return void
@@ -769,7 +752,6 @@ class ItemList implements IServiceContainerAware
             ->dispatch(MetaModelsEvents::RENDER_ITEM_LIST, $event);
 
         $this->objTemplate->noItemsMsg = $this->getNoItemsCaption();
-        $this->objTemplate->details    = $this->getDetailsCaption();
 
         $this->prepare();
         $strOutputFormat = $this->getOutputFormat();


### PR DESCRIPTION
## Description

Add the variable createEnable to the MetaModel list template. There is no need to show the addUrl button if the table is not creatable.
See MetaModels/contao-frontend-editing#7

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
