### PR TITLE
Introduce `IItem::getVariantBase()`

### DIFF
--- a/src/MetaModels/IItem.php
+++ b/src/MetaModels/IItem.php
@@ -112,6 +112,13 @@ interface IItem
     public function getVariants($objFilter);
 
     /**
+     * Fetch the meta model variant base for this item. For a non-variant item the variant base is the item itself.
+     *
+     * @return \MetaModels\IItem The variant base.
+     */
+    public function getVariantBase();
+
+    /**
      * Save the current data for every attribute to the data sink.
      *
      * @return void

--- a/src/MetaModels/IItem.php
+++ b/src/MetaModels/IItem.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2015 The MetaModels team.
+ * (c) 2012-2017 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -14,7 +14,8 @@
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
- * @copyright  2012-2015 The MetaModels team.
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */

--- a/src/MetaModels/IItem.php
+++ b/src/MetaModels/IItem.php
@@ -107,14 +107,16 @@ interface IItem
      *
      * @param \MetaModels\Filter\IFilter $objFilter The filter settings to be applied.
      *
-     * @return \MetaModels\IItems A list of all variants for this item.
+     * @return \MetaModels\IItems|null A list of all variants for this item or null if the item cannot handle variants.
      */
     public function getVariants($objFilter);
 
     /**
-     * Fetch the meta model variant base for this item. For a non-variant item the variant base is the item itself.
+     * Fetch the meta model variant base for this item.
      *
-     * @return \MetaModels\IItem The variant base.
+     * Note: For a non-variant item the variant base is the item itself.
+     *
+     * @return IItem The variant base.
      */
     public function getVariantBase();
 

--- a/src/MetaModels/Item.php
+++ b/src/MetaModels/Item.php
@@ -295,6 +295,16 @@ class Item implements IItem
     }
 
     /**
+     * Fetch the meta model variant base for this item. For a non-variant item the variant base is the item itself.
+     *
+     * @return \MetaModels\IItem The variant base.
+     */
+    public function getVariantBase()
+    {
+        // TODO: Implement getVariantBase() method.
+    }
+
+    /**
      * Find all Variants including the variant base.
      *
      * The item itself is excluded from the return list.

--- a/src/MetaModels/Item.php
+++ b/src/MetaModels/Item.php
@@ -301,7 +301,11 @@ class Item implements IItem
      */
     public function getVariantBase()
     {
-        // TODO: Implement getVariantBase() method.
+        if (!$this->isVariantBase()) {
+            return $this->getMetaModel()->findById($this->get('vargroup'));
+        }
+
+        return $this;
     }
 
     /**

--- a/src/MetaModels/Item.php
+++ b/src/MetaModels/Item.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2015 The MetaModels team.
+ * (c) 2012-2017 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -18,7 +18,7 @@
  * @author     Oliver Hoff <oliver@hofff.com>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright  2012-2015 The MetaModels team.
+ * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */

--- a/src/MetaModels/Item.php
+++ b/src/MetaModels/Item.php
@@ -283,7 +283,7 @@ class Item implements IItem
      *
      * @param IFilter $objFilter The filter settings to be applied.
      *
-     * @return IItems A list of all variants for this item.
+     * @return IItems|null A list of all variants for this item.
      */
     public function getVariants($objFilter)
     {
@@ -295,9 +295,11 @@ class Item implements IItem
     }
 
     /**
-     * Fetch the meta model variant base for this item. For a non-variant item the variant base is the item itself.
+     * Fetch the meta model variant base for this item.
      *
-     * @return \MetaModels\IItem The variant base.
+     * Note: For a non-variant item the variant base is the item itself.
+     *
+     * @return IItem The variant base.
      */
     public function getVariantBase()
     {


### PR DESCRIPTION
## Description

Introduce the `IItem::getVariantBase()` as described in #237.

Unit tests for `IItem::getVariants()`, `IItem::isVariant()`, `IItem::isVariantBase()`, `IItem::getVariantBase()` unneeded?

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues