### PR TITLE
Add identifier for internal attribute for exclude by some methods

### DIFF
--- a/src/MetaModels/Attribute/IInternal.php
+++ b/src/MetaModels/Attribute/IInternal.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of MetaModels/core.
+ *
+ * (c) 2012-2017 The MetaModels team.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    MetaModels
+ * @subpackage Core
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2012-2017 The MetaModels team.
+ * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
+ * @filesource
+ */
+
+namespace MetaModels\Attribute;
+
+/**
+ * Interface for "internal" MetaModel attributes.
+ * This interface is helper for check if the attribute is internal.
+ */
+interface IInternal
+{
+}

--- a/src/MetaModels/DcGeneral/Events/Table/RenderSetting/Subscriber.php
+++ b/src/MetaModels/DcGeneral/Events/Table/RenderSetting/Subscriber.php
@@ -37,6 +37,7 @@ use ContaoCommunityAlliance\DcGeneral\DataDefinition\Palette\PaletteInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Palette\Property;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Palette\PropertyInterface;
 use ContaoCommunityAlliance\DcGeneral\Factory\Event\BuildDataDefinitionEvent;
+use MetaModels\Attribute\IInternal;
 use MetaModels\BackendIntegration\TemplateList;
 use MetaModels\DcGeneral\DataDefinition\Palette\Condition\Palette\RenderSettingAttributeIs as PaletteCondition;
 use MetaModels\DcGeneral\DataDefinition\Palette\Condition\Property\RenderSettingAttributeIs as PropertyCondition;
@@ -247,7 +248,9 @@ class Subscriber extends BaseSubscriber
             ->fetchEach('attr_id');
 
         foreach ($metaModel->getAttributes() as $attribute) {
-            if (in_array($attribute->get('id'), $alreadyTaken)) {
+            if ($attribute instanceof IInternal
+                || in_array($attribute->get('id'), $alreadyTaken)
+            ) {
                 continue;
             }
             $arrResult[$attribute->get('id')] = sprintf(

--- a/src/MetaModels/Item.php
+++ b/src/MetaModels/Item.php
@@ -18,6 +18,7 @@
  * @author     Oliver Hoff <oliver@hofff.com>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
  * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -26,6 +27,7 @@
 namespace MetaModels;
 
 use MetaModels\Attribute\IAttribute;
+use MetaModels\Attribute\IInternal;
 use MetaModels\Events\ParseItemEvent;
 use MetaModels\Filter\IFilter;
 use MetaModels\Render\Setting\ICollection;
@@ -100,7 +102,12 @@ class Item implements IItem
      */
     public function internalParseAttribute($objAttribute, $strOutputFormat, $objSettings)
     {
+        if ($objAttribute instanceof IInternal) {
+            return array();
+        }
+
         $arrResult = array();
+
         if ($objAttribute) {
             // Extract view settings for this attribute.
             if ($objSettings) {


### PR DESCRIPTION
This feature is useful for better work with virtual attribute.
Virtual attribute has problem if we get parse values from item.
You can see this by attribute_file by the virtual [FileOrder](https://github.com/ContaoBlackForest-archive/attribute_file/blob/32516ce6ab82aa3809c2e32185f68b4055b3f648/src/MetaModels/Attribute/File/FileOrder.php#L36).