### PR TITLE
Hotfix DCA picker - correct the path to js and css

### DIFF
--- a/contao/templates/be_dcastylepicker.html5
+++ b/contao/templates/be_dcastylepicker.html5
@@ -8,7 +8,7 @@
   $objCombiner = new Combiner();
   $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
   $objCombiner->add('system/themes/'. $this->theme .'/main.css');
-  echo $objCombiner->getCombinedFile();
+  echo $objCombiner->getCombinedFile('');
 ?>" media="all">
 <!--[if IE]><link rel="stylesheet" href="<?= TL_SCRIPT_URL ?>system/themes/<?= $this->theme ?>/iefixes.css" media="screen"><![endif]-->
 <?= $this->stylesheets ?>
@@ -44,7 +44,7 @@ var REQUEST_TOKEN = '<?= REQUEST_TOKEN ?>';
   $objCombiner->add('assets/mootools/mootao/Mootao.js', MOOTOOLS_TAO);
   $objCombiner->add('assets/contao/js/core.js');
   $objCombiner->add('system/themes/'. $this->theme .'/hover.js');
-  echo $objCombiner->getCombinedFile();
+  echo $objCombiner->getCombinedFile('');
 ?>"></script>
 
 <?php if($this->strField == 'panelLayout'): ?>


### PR DESCRIPTION
Hotfix DCA picker - correct the path to js and css

thx to @baumannsven for the tip to add `''` :-)