### PR TITLE
Respect the "meta" array in the ToolboxFileTest

### DIFF
--- a/tests/MetaModels/Test/Helper/ToolBoxFileTest.php
+++ b/tests/MetaModels/Test/Helper/ToolBoxFileTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2015 The MetaModels team.
+ * (c) 2012-2017 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    MetaModels
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  2012-2015 The MetaModels team.
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -40,7 +41,8 @@ class ToolBoxFileTest extends TestCase
         $emptyExpected = array(
             'bin'   => array(),
             'value' => array(),
-            'path'  => array()
+            'path'  => array(),
+            'meta'  => array()
         );
 
         $this->assertEquals($emptyExpected, ToolboxFile::convertUuidsOrPathsToMetaModels(null));


### PR DESCRIPTION
## Description

Respect the "meta" array in the `ToolboxFileTest`. Changes introduced via #1116

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
