### PR TITLE
Hotfix issue #1154 delete standard chx at rendersetting and input mask

### DIFF
--- a/contao/dca/tl_metamodel_dca.php
+++ b/contao/dca/tl_metamodel_dca.php
@@ -20,6 +20,7 @@
  * @author     Alexander Menk <a.menk@imi.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @author     Ingolf Steinhardt <info@e-spin.de>
  * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -221,8 +222,7 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
         (
             'title'       => array
             (
-                'name',
-                'isdefault'
+                'name'
             ),
             'view'        => array
             (
@@ -303,18 +303,6 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
                 'tl_class'  => 'w50'
             ),
             'sql'       => "varchar(255) NOT NULL default ''"
-        ),
-        'isdefault'      => array
-        (
-            'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['isdefault'],
-            'exclude'   => true,
-            'inputType' => 'checkbox',
-            'eval'      => array
-            (
-                'tl_class' => 'w50 m12 cbx',
-                'fallback' => true
-            ),
-            'sql'       => "char(1) NOT NULL default ''"
         ),
         'rendertype'     => array
         (

--- a/contao/dca/tl_metamodel_rendersettings.php
+++ b/contao/dca/tl_metamodel_rendersettings.php
@@ -20,6 +20,7 @@
  * @author     Alexander Menk <a.menk@imi.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @author     Ingolf Steinhardt <info@e-spin.de>
  * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -194,8 +195,7 @@ $GLOBALS['TL_DCA']['tl_metamodel_rendersettings'] = array
         (
             'title'   => array
             (
-                'name',
-                'isdefault'
+                'name'
             ),
             'general' => array
             (
@@ -241,18 +241,6 @@ $GLOBALS['TL_DCA']['tl_metamodel_rendersettings'] = array
                 'tl_class'  => 'w50'
             ),
             'sql'       => "varchar(64) NOT NULL default ''"
-        ),
-        'isdefault'       => array
-        (
-            'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_rendersettings']['isdefault'],
-            'exclude'   => true,
-            'inputType' => 'checkbox',
-            'eval'      => array
-            (
-                'tl_class' => 'm12 w50 cbx',
-                'fallback' => true
-            ),
-            'sql'       => "char(1) NOT NULL default ''"
         ),
         'hideEmptyValues' => array
         (

--- a/contao/languages/en/tl_metamodel_dca.php
+++ b/contao/languages/en/tl_metamodel_dca.php
@@ -13,6 +13,7 @@
  * @package    MetaModels
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Ingolf Steinhardt <info@e-spin.de>
  * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -22,9 +23,6 @@ $GLOBALS['TL_LANG']['tl_metamodel_dca']['name'][0]                     = 'Name';
 $GLOBALS['TL_LANG']['tl_metamodel_dca']['name'][1]                     = 'Name of the input screen.';
 $GLOBALS['TL_LANG']['tl_metamodel_dca']['tstamp'][0]                   = 'Revision date';
 $GLOBALS['TL_LANG']['tl_metamodel_dca']['tstamp'][1]                   = 'Date and time of the latest revision.';
-$GLOBALS['TL_LANG']['tl_metamodel_dca']['isdefault'][0]                = 'Is default';
-$GLOBALS['TL_LANG']['tl_metamodel_dca']['isdefault'][1]                =
-    'Determines that this input screen shall be used as default for the parenting MetaModel.';
 $GLOBALS['TL_LANG']['tl_metamodel_dca']['rendertype'][0]               = 'Integration';
 $GLOBALS['TL_LANG']['tl_metamodel_dca']['rendertype'][1]               = 'Select the desired type of integration.';
 $GLOBALS['TL_LANG']['tl_metamodel_dca']['rendermode'][0]               = 'Render mode';

--- a/contao/languages/en/tl_metamodel_rendersettings.php
+++ b/contao/languages/en/tl_metamodel_rendersettings.php
@@ -13,6 +13,7 @@
  * @package    MetaModels
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Ingolf Steinhardt <info@e-spin.de>
  * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -26,9 +27,6 @@ $GLOBALS['TL_LANG']['tl_metamodel_rendersettings']['name'][0]                 = 
 $GLOBALS['TL_LANG']['tl_metamodel_rendersettings']['name'][1]                 = 'Setting name.';
 $GLOBALS['TL_LANG']['tl_metamodel_rendersettings']['tstamp'][0]               = 'Revision date';
 $GLOBALS['TL_LANG']['tl_metamodel_rendersettings']['tstamp'][1]               = 'Date and time of the latest revision.';
-$GLOBALS['TL_LANG']['tl_metamodel_rendersettings']['isdefault'][0]            = 'Is default';
-$GLOBALS['TL_LANG']['tl_metamodel_rendersettings']['isdefault'][1]            =
-    'Determines that this setting shall be used as default for the parenting MetaModel.';
 $GLOBALS['TL_LANG']['tl_metamodel_rendersettings']['template'][0]             = 'Template';
 $GLOBALS['TL_LANG']['tl_metamodel_rendersettings']['template'][1]             =
     'The template to use to render the items.';

--- a/src/MetaModels/DcGeneral/Events/Table/InputScreen/Subscriber.php
+++ b/src/MetaModels/DcGeneral/Events/Table/InputScreen/Subscriber.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2015 The MetaModels team.
+ * (c) 2012-2017 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    MetaModels
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  2012-2015 The MetaModels team.
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -59,10 +60,6 @@ class Subscriber extends BaseSubscriber
             ->addListener(
                 BuildDataDefinitionEvent::NAME,
                 array($this, 'setParentTableVisibility')
-            )
-            ->addListener(
-                ModelToLabelEvent::NAME,
-                array($this, 'modelToLabel')
             )
             ->addListener(
                 ManipulateWidgetEvent::NAME,
@@ -117,32 +114,6 @@ class Subscriber extends BaseSubscriber
                 $chain->addCondition(new PropertyValueCondition('rendertype', 'ctable'));
             }
         }
-    }
-
-    /**
-     * Render the html for the input screen.
-     *
-     * @param ModelToLabelEvent $event The event.
-     *
-     * @return void
-     */
-    public function modelToLabel(ModelToLabelEvent $event)
-    {
-        if (($event->getEnvironment()->getDataDefinition()->getName() !== 'tl_metamodel_dca')) {
-            return;
-        }
-
-        $environment = $event->getEnvironment();
-        $translator  = $environment->getTranslator();
-        $model       = $event->getModel();
-
-        if (!$model->getProperty('isdefault')) {
-            return;
-        }
-
-        $event
-            ->setArgs(array_merge($event->getArgs(), array($translator->translate('MSC.fallback'))))
-            ->setLabel(sprintf('%s <span style="color:#b3b3b3; padding-left:3px">[%%s]</span>', $event->getLabel()));
     }
 
     /**

--- a/src/MetaModels/DcGeneral/Events/Table/RenderSettings/Subscriber.php
+++ b/src/MetaModels/DcGeneral/Events/Table/RenderSettings/Subscriber.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2015 The MetaModels team.
+ * (c) 2012-2017 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -14,7 +14,8 @@
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Martin Treml <github@r2pi.net>
- * @copyright  2012-2015 The MetaModels team.
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -59,10 +60,6 @@ class Subscriber extends BaseSubscriber
                 }
             )
             ->addListener(
-                ModelToLabelEvent::NAME,
-                array($this, 'modelToLabel')
-            )
-            ->addListener(
                 DecodePropertyValueForWidgetEvent::NAME,
                 array($this, 'decodeJumpToValue')
             )
@@ -86,30 +83,6 @@ class Subscriber extends BaseSubscriber
                 GetOptionsEvent::NAME,
                 array($this, 'getJsFilesOptions')
             );
-    }
-
-    /**
-     * Draw the render setting.
-     *
-     * @param ModelToLabelEvent $event The event.
-     *
-     * @return void
-     *
-     * @SuppressWarnings(PHPMD.Superglobals)
-     * @SuppressWarnings(PHPMD.CamelCaseVariableName)
-     */
-    public function modelToLabel(ModelToLabelEvent $event)
-    {
-        if (($event->getEnvironment()->getDataDefinition()->getName() !== 'tl_metamodel_rendersettings')) {
-            return;
-        }
-
-        if ($event->getModel()->getProperty('isdefault')) {
-            $event->setLabel(
-                $event->getLabel() .
-                ' <span style="color:#b3b3b3; padding-left:3px">[' . $GLOBALS['TL_LANG']['MSC']['fallback'] . ']</span>'
-            );
-        }
     }
 
     /**

--- a/src/MetaModels/Helper/ViewCombinations.php
+++ b/src/MetaModels/Helper/ViewCombinations.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2015 The MetaModels team.
+ * (c) 2012-2017 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    MetaModels
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  2012-2015 The MetaModels team.
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -228,8 +229,6 @@ abstract class ViewCombinations
             $found = array();
         }
 
-        $this->getPaletteCombinationDefault($found);
-
         // Clean any undefined.
         foreach (array_keys($this->information) as $tableName) {
             if (empty($this->information[$tableName][self::COMBINATION])
@@ -366,85 +365,6 @@ abstract class ViewCombinations
         return $success;
     }
 
-    /**
-     * Get the default input screens (if any has been defined).
-     *
-     * @param int[] $metaModelIds The MetaModels for which input screens shall NOT be retrieved.
-     *
-     * @return void
-     */
-    protected function getDefaultInputScreens($metaModelIds)
-    {
-        $sqlWhere = '';
-        if ($metaModelIds) {
-            $sqlWhere = sprintf('pid NOT IN (%s) AND', implode(',', array_fill(0, count($metaModelIds), '?')));
-        }
-
-        $inputScreen = $this->getDatabase()
-            ->prepare(sprintf('SELECT * FROM tl_metamodel_dca WHERE %s isdefault=1', $sqlWhere))
-            ->execute($metaModelIds);
-
-        while ($inputScreen->next()) {
-            /** @noinspection PhpUndefinedFieldInspection */
-            $modelId   = $inputScreen->pid;
-            $modelName = $this->tableNameFromId($modelId);
-
-            if (!isset($this->tableMap[$modelId])) {
-                $this->setTableMapping($modelId, $modelName);
-            }
-
-            /** @noinspection PhpUndefinedFieldInspection */
-            $this->information[$modelName][self::COMBINATION]['dca_id'] = $inputScreen->id;
-        }
-    }
-
-    /**
-     * Get the default render settings (if any has been defined).
-     *
-     * @param int[] $metaModelIds The MetaModels for which render settings shall NOT be retrieved.
-     *
-     * @return void
-     */
-    protected function getDefaultRenderSettings($metaModelIds)
-    {
-        $sqlWhere = '';
-        if ($metaModelIds) {
-            $sqlWhere = sprintf('pid NOT IN (%s) AND', implode(',', array_fill(0, count($metaModelIds), '?')));
-        }
-
-        $renderSetting = $this->getDatabase()
-            ->prepare(sprintf(
-                'SELECT * FROM tl_metamodel_rendersettings WHERE %s isdefault=1',
-                $sqlWhere
-            ))
-            ->execute($metaModelIds);
-
-        while ($renderSetting->next()) {
-            /** @noinspection PhpUndefinedFieldInspection */
-            $modelId   = $renderSetting->pid;
-            $modelName = $this->tableNameFromId($modelId);
-
-            if (!isset($this->tableMap[$modelId])) {
-                $this->setTableMapping($modelId, $modelName);
-            }
-
-            /** @noinspection PhpUndefinedFieldInspection */
-            $this->information[$modelName][self::COMBINATION]['view_id'] = $renderSetting->id;
-        }
-    }
-
-    /**
-     * Get the default combination of palette and view (if any has been defined).
-     *
-     * @param int[] $metaModelIds The MetaModels for which combinations shall NOT be retrieved.
-     *
-     * @return void
-     */
-    protected function getPaletteCombinationDefault($metaModelIds)
-    {
-        $this->getDefaultInputScreens($metaModelIds);
-        $this->getDefaultRenderSettings($metaModelIds);
-    }
 
     /**
      * Pull in all DCA settings for the buffered MetaModels and buffer them in the static class.

--- a/src/MetaModels/Render/Setting/RenderSettingFactory.php
+++ b/src/MetaModels/Render/Setting/RenderSettingFactory.php
@@ -121,7 +121,7 @@ class RenderSettingFactory implements IRenderSettingFactory
     {
         $row = $this->serviceContainer->getDatabase()
             ->prepare(
-                'SELECT * FROM tl_metamodel_rendersettings WHERE pid=? AND (id=? OR isdefault=1) ORDER BY isdefault ASC'
+                'SELECT * FROM tl_metamodel_rendersettings WHERE pid=? AND id=?'
             )
             ->limit(1)
             ->execute($metaModel->get('id'), $settingId ?: 0);


### PR DESCRIPTION
Hotfix issue #1154 delete standard chx at rendersetting and input mask - it´s obsolete because we use only "Permissions for input screen and views"