### PR TITLE
[POC] "Additional filters" for the input screen settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "contao-community-alliance/dependency-container": "~1.6",
     "contao-community-alliance/event-dispatcher": "~1.3",
     "contao-community-alliance/events-contao-bindings": "~3.2",
-    "doctrine/cache": "~1.3"
+    "doctrine/cache": "~1.3",
+    "symfony/expression-language": "^3.3"
   },
   "require-dev": {
     "cyberspectrum/contao-toolbox": "~0.6",

--- a/contao/dca/tl_metamodel_dca.php
+++ b/contao/dca/tl_metamodel_dca.php
@@ -244,6 +244,7 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
                 'iseditable',
                 'iscreatable',
                 'isdeleteable',
+                'additionalFilters'
             ),
         )
     ),
@@ -488,6 +489,43 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
                 'tl_class' => 'w50 m12 cbx',
             ),
             'sql'       => "char(1) NOT NULL default ''"
-        )
+        ),
+        'additionalFilters' => array
+        (
+            'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['additionalFilters'],
+            'exclude'   => true,
+            'inputType' => 'multiColumnWizard',
+            'eval'      => array
+            (
+                'tl_class'     => 'clr',
+                'columnFields' => array
+                (
+                    'property'    => array
+                    (
+                        'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['addfilter_property'],
+                        'exclude'   => true,
+                        'inputType' => 'select',
+                        'eval'      => array
+                        (
+                            'tl_class'           => 'clr',
+                            'style'              => 'width:200px',
+                            'includeBlankOption' => true,
+                            'chosen'             => 'true',
+                        )
+                    ),
+                    'expression'       => array
+                    (
+                        'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_dca']['addfilter_expression'],
+                        'exclude'   => true,
+                        'inputType' => 'text',
+                        'eval'      => array
+                        (
+                            'style' => 'width:180px',
+                        )
+                    ),
+                ),
+            ),
+            'sql'       => "text NULL"
+        ),
     )
 );


### PR DESCRIPTION
## Description

@zonky2 sent me a link to the [Contao Community](https://community.contao.org/de/showthread.php?52542-Backend-Liste-filtern-Wie-macht-man-das).
This POC brings this use case functionality to the core.

For instance:
In the backend, a user must only edit his/her items.
![screen shot 2017-11-04 at 23 53 02](https://user-images.githubusercontent.com/1284725/32410210-85189a0c-c1bb-11e7-80ad-6aacb5dbffe3.png)
(property: attribute of the item, expression: value for the filter using expression language)

## Checklist
- [ ] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
