### PR TITLE
Bring backwards compatibility for changes introduced in #1078

### DIFF
--- a/src/MetaModels/ItemList.php
+++ b/src/MetaModels/ItemList.php
@@ -752,6 +752,8 @@ class ItemList implements IServiceContainerAware
             ->dispatch(MetaModelsEvents::RENDER_ITEM_LIST, $event);
 
         $this->objTemplate->noItemsMsg = $this->getNoItemsCaption();
+        // Backwards compatibility with templates as of #1078
+        $this->objTemplate->details = $this->getCaptionText('details');
 
         $this->prepare();
         $strOutputFormat = $this->getOutputFormat();


### PR DESCRIPTION
## Description

We removed the template var `$this->details`. As this var is used in templates widely, we bring it back.
#1206 

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
