### PR TITLE
[RTM] Initialize attributes with empty values.

### DIFF
--- a/src/MetaModels/DcGeneral/Data/Driver.php
+++ b/src/MetaModels/DcGeneral/Data/Driver.php
@@ -18,6 +18,7 @@
  * @author     David Molineus <david.molineus@netzmacht.de>
  * @author     binron <rtb@gmx.ch>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2012-2018 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -304,7 +305,7 @@ class Driver implements MultiLanguageDataProviderInterface
      */
     public function getEmptyModel()
     {
-        $objItem = new Item($this->getMetaModel(), array());
+        $objItem = new Item($this->getMetaModel(), null);
         return new Model($objItem);
     }
 

--- a/src/MetaModels/Item.php
+++ b/src/MetaModels/Item.php
@@ -61,10 +61,19 @@ class Item implements IItem
      *
      * @param IMetaModel $objMetaModel The model this item is represented by.
      *
-     * @param array      $arrData      The initial data that shall be injected into the new instance.
+     * @param array|null $arrData      The initial data that shall be injected into the new instance.
      */
     public function __construct(IMetaModel $objMetaModel, $arrData)
     {
+        if (null === $arrData) {
+            // Initialize attributes with empty values.
+            $arrData = [];
+
+            foreach ($objMetaModel->getAttributes() as $attribute) {
+                $arrData[$attribute->getColName()] = null;
+            }
+        }
+
         $this->arrData   = $arrData;
         $this->metaModel = $objMetaModel;
     }


### PR DESCRIPTION
## Issue

When creating a new item and finally saving the item, neither the alias attributes nor the combined values attributes get generated.

## Description

The item gets initialized with `$arrData = []` meaning we have to initialize all attributes so that they are present in the data array. This is related to #894 and 588eddf respectively.
When `$arrData` is empty, `isAttributeSet()` returns `false` which results in no attributes get notified about a model change.

## Reproduction

1. Using the API
```php
$item = new Item($metaModel, null);
$item->set('name', 'Test');
$item->save();
// neither alias nor combined values have been generated now
```

2. Using the Frontend Editing.
Neither alias nor combined values are generated on creation.

3. MetaModels 2.0 as well 2.1 are affected.

## To be discussed

* We might want to add a `getEmptyValue()` to the `IAttribute`.
* We can move the new logic from the model to the `getEmptyModel()`.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
