### PR TITLE
[WIP] Introduce the "ItemList modify filter" event.

### DIFF
--- a/src/MetaModels/Events/ItemListModifyFilterEvent.php
+++ b/src/MetaModels/Events/ItemListModifyFilterEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of MetaModels/core.
+ *
+ * (c) 2012-2018 The MetaModels team.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    MetaModels
+ * @subpackage Core
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2012-2018 The MetaModels team.
+ * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
+ * @filesource
+ */
+
+namespace MetaModels\Events;
+
+use MetaModels\ItemList;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * This event is fired within the modifyFilter() of an ItemList.
+ */
+class ItemListModifyFilterEvent extends Event
+{
+
+    /**
+     * The item list.
+     *
+     * @var ItemList
+     */
+    private $itemList;
+
+    /**
+     * ItemListModifyFilterEvent constructor.
+     *
+     * @param ItemList $itemList The item list.
+     */
+    public function __construct(ItemList $itemList)
+    {
+        $this->itemList = $itemList;
+    }
+
+    /**
+     * Returns the item list.
+     *
+     * @return ItemList
+     */
+    public function getItemList()
+    {
+        return $this->itemList;
+    }
+}

--- a/src/MetaModels/ItemList.php
+++ b/src/MetaModels/ItemList.php
@@ -30,6 +30,7 @@
 namespace MetaModels;
 
 use Contao\StringUtil;
+use MetaModels\Events\ItemListModifyFilterEvent;
 use MetaModels\Events\RenderItemListEvent;
 use MetaModels\Helper\PaginationLimitCalculator;
 use MetaModels\Render\Template;
@@ -461,6 +462,11 @@ class ItemList implements IServiceContainerAware
      */
     protected function modifyFilter()
     {
+        $this->eventDispatcher->dispatch(
+            MetaModelsEvents::ITEM_LIST_MODIFY_FILTER,
+            new ItemListModifyFilterEvent($this)
+        );
+
         return $this;
     }
 

--- a/src/MetaModels/MetaModelsEvents.php
+++ b/src/MetaModels/MetaModelsEvents.php
@@ -14,6 +14,7 @@
  * @subpackage Core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2012-2018 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -89,4 +90,11 @@ class MetaModelsEvents
      * @see \MetaModels\Events\RenderItemListEvent.
      */
     const RENDER_ITEM_LIST = 'metamodels.render-item-list';
+
+    /**
+     * Event prior evaluating the filter of an item list.
+     *
+     * @see \MetaModels\Events\ItemListModifyFilterEvent.
+     */
+    const ITEM_LIST_MODIFY_FILTER = 'metamodels.item-list-modify-filter';
 }


### PR DESCRIPTION
## Description

This event is fired within the `modifyFilter()` of an `ItemList`.
This allows you to modify the filter of a MetaModel list on runtime.

**Use case:** your application may have two different states, e.g. "Summer" or "Winter". Depending on what state is active, the item list must only display the items belonging to the current state (e.g. "Summer").

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
