### PR TITLE
[RTM] Fix warnings in the picker widget.

### DIFF
--- a/src/MetaModels/Widgets/PickerWidget.php
+++ b/src/MetaModels/Widgets/PickerWidget.php
@@ -18,6 +18,7 @@
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     David Maack <david.maack@arcor.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  2012-2018 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource

--- a/src/MetaModels/Widgets/PickerWidget.php
+++ b/src/MetaModels/Widgets/PickerWidget.php
@@ -51,6 +51,7 @@ class PickerWidget
     public function __construct()
     {
         BackendUser::getInstance()->authenticate();
+        Controller::setStaticUrls();
         Controller::loadLanguageFile('default');
         Controller::loadLanguageFile('modules');
     }


### PR DESCRIPTION
## Description

The picker widget show warnings about missing constants  TL_ASSETS_URL and TL_FILES_URL. This PR fixes it by calling `Controller::setStaticUrls()` which defines the constants.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
