### PR TITLE
Check for array.

### DIFF
--- a/src/DcGeneral/Data/FilterBuilder.php
+++ b/src/DcGeneral/Data/FilterBuilder.php
@@ -14,6 +14,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2012-2019 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -297,7 +298,7 @@ class FilterBuilder
                 $subProcedure = new FilterBuilderSql($tableName, $child['operation'], $this->connection);
                 $subSkipped   = $this->buildNativeSqlProcedure($subProcedure, $child['children']);
 
-                if (count($subSkipped) !== count($child['children'])) {
+                if (\is_array($child['children']) && count($subSkipped) !== count($child['children'])) {
                     $procedure->addSubProcedure($subProcedure);
                 }
 


### PR DESCRIPTION
## Description

This fixes a PHP 7.2. compatibility: 
`count(): Parameter must be an array or an object that implements Countable`
See https://sentry.io/share/issue/7687bab48f2f42fdaa5f69875f9f322d/.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
