### PR TITLE
Rewrite SubSystemBoot as registered service.

### DIFF
--- a/src/CoreBundle/Resources/config/listeners.yml
+++ b/src/CoreBundle/Resources/config/listeners.yml
@@ -48,6 +48,12 @@ services:
                 event: dc-general.model.pre-duplicate
                 method: handle
 
+    metamodels.sub_system_boot:
+        class: MetaModels\CoreBundle\EventListener\SubSystemBootListener
+        arguments:
+          ['@contao.framework', '@database_connection', '@logger', '@cca.dc-general.scope-matcher', '@event_dispatcher']
+        public: true
+
     MetaModels\CoreBundle\EventListener\PurgeListener:
         arguments:
             - '@metamodels.cache.purger'

--- a/src/CoreBundle/Resources/contao/config/config.php
+++ b/src/CoreBundle/Resources/contao/config/config.php
@@ -20,6 +20,7 @@
  * @author     Christopher Boelter <christopher@boelter.eu>
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2012-2019 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -127,10 +128,7 @@ if (!isset($GLOBALS['MM_FILTER_PARAMS'])) {
     $GLOBALS['MM_FILTER_PARAMS'] = array();
 }
 
-$GLOBALS['TL_HOOKS']['initializeDependencyContainer'][] = function () {
-    $handler = new MetaModels\Helper\SubSystemBoot();
-    $handler->boot();
-};
+$GLOBALS['TL_HOOKS']['initializeSystem'][] = ['metamodels.sub_system_boot', 'boot'];
 
 $GLOBALS['TL_HOOKS']['getUserNavigation'][] =
     [MetaModels\CoreBundle\Contao\Hooks\RegisterBackendNavigation::class, 'onGetUserNavigation'];


### PR DESCRIPTION
## Description

This PR rewrites the SubSystemBoot class as registered service.

This PR fixes the error
"The "logger" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead."

I needed to inject the `logger` service because it is not public.

<img width="1396" alt="Screen Shot 2019-04-13 at 00 06 46" src="https://user-images.githubusercontent.com/1284725/56068777-5d0f6d80-5d80-11e9-9e22-e41d1d764436.png">


## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
