### PR TITLE
Hotfix for custom SQL filter

### DIFF
--- a/src/CoreBundle/Contao/Compat/ContaoFactory.php
+++ b/src/CoreBundle/Contao/Compat/ContaoFactory.php
@@ -72,4 +72,18 @@ class ContaoFactory
 
         return $this->framework->getAdapter($className);
     }
+
+    /**
+     * Create an instance.
+     *
+     * @param string $className The class name to create an instance for.
+     *
+     * @return object
+     */
+    public function createInstance($className)
+    {
+        $this->framework->initialize();
+
+        return $this->framework->createInstance($className);
+    }
 }

--- a/src/CoreBundle/Resources/config/services.yml
+++ b/src/CoreBundle/Resources/config/services.yml
@@ -66,7 +66,7 @@ services:
 
     metamodels.contao_session:
         class: Contao\Session
-        factory: ['@MetaModels\CoreBundle\Contao\Compat\ContaoFactory', 'getAdapter']
+        factory: ['@MetaModels\CoreBundle\Contao\Compat\ContaoFactory', 'createInstance']
         arguments:
             - 'Contao\Session'
 


### PR DESCRIPTION
Session access inside a custom SQL filter e.g.
`{{param::session?name=mm_blog_post_id&default=0}}`

Throws an exception like this:
`Using $this when not in object context`

Unlike Contao\Input Contao\Session has to be instantiated by getInstance()

<img width="864" alt="Screen Shot 2019-05-14 at 16 50 44" src="https://user-images.githubusercontent.com/3243377/57708326-6df61c00-7669-11e9-8ce2-c94fd8c4b3c8.png">
<img width="1057" alt="Screen Shot 2019-05-14 at 16 34 31" src="https://user-images.githubusercontent.com/3243377/57708352-764e5700-7669-11e9-803c-898a50b430b4.png">