### PR TITLE
[RTM] Update FixupUserGroupModules.php

### DIFF
--- a/src/CoreBundle/Contao/Hooks/FixupUserGroupModules.php
+++ b/src/CoreBundle/Contao/Hooks/FixupUserGroupModules.php
@@ -83,7 +83,7 @@ class FixupUserGroupModules
         }
 
         $original = new \tl_user_group();
-        $modules  = $original->getModules();
+        $modules  = $original->getModules($dataContainer);
 
         // 1. remove all MetaModels
         foreach (array_keys($modules) as $group) {

--- a/src/CoreBundle/Contao/Hooks/FixupUserGroupModules.php
+++ b/src/CoreBundle/Contao/Hooks/FixupUserGroupModules.php
@@ -12,6 +12,7 @@
  *
  * @package    MetaModels/core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Ben <kampfq@users.noreply.github.com>
  * @copyright  2012-2019 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource


### PR DESCRIPTION
## Description

fix Type error: Too few arguments to function tl_user_group::getModules(), 0 passed in /var/www/html/vendor/metamodels/core/src/CoreBundle/Contao/Hooks/FixupUserGroupModules.php on line 86 and exactly 1 expected


## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
