### PR TITLE
[RTM] Pass absolute paths to the image factory

### DIFF
--- a/src/CoreBundle/Assets/IconBuilder.php
+++ b/src/CoreBundle/Assets/IconBuilder.php
@@ -14,6 +14,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  2012-2019 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -25,6 +26,7 @@ use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Image\ImageFactoryInterface;
 use Contao\Validator;
 use Symfony\Component\Filesystem\Filesystem;
+use Webmozart\PathUtil\Path;
 
 /**
  * This class takes care of building icons for the backend.
@@ -51,6 +53,13 @@ class IconBuilder
      * @var string
      */
     private $webPath;
+
+    /**
+     * The project web reachable path for assets.
+     *
+     * @var string
+     */
+    private $projectWebPath;
 
     /**
      * Adapter to the Contao\FilesModel class.
@@ -82,6 +91,7 @@ class IconBuilder
      * @param string                $outputPath   The output path for assets.
      * @param string                $webPath      The web reachable path for assets.
      * @param Adapter               $imageAdapter The image adapter to generate HTML code images.
+     * @param string                $webPath      The project web reachable path for assets.
      */
     public function __construct(
         Adapter $filesAdapter,
@@ -89,14 +99,16 @@ class IconBuilder
         $rootPath,
         $outputPath,
         $webPath,
-        Adapter $imageAdapter
+        Adapter $imageAdapter,
+        $projectWebPath
     ) {
-        $this->filesAdapter = $filesAdapter;
-        $this->imageFactory = $imageFactory;
-        $this->rootPath     = $rootPath;
-        $this->outputPath   = $outputPath;
-        $this->webPath      = $webPath;
-        $this->image        = $imageAdapter;
+        $this->filesAdapter   = $filesAdapter;
+        $this->imageFactory   = $imageFactory;
+        $this->rootPath       = $rootPath;
+        $this->outputPath     = $outputPath;
+        $this->webPath        = $webPath;
+        $this->projectWebPath = $projectWebPath;
+        $this->image          = $imageAdapter;
 
         // Ensure output path exists.
         $fileSystem = new Filesystem();
@@ -115,11 +127,16 @@ class IconBuilder
     {
         $realIcon   = $this->convertValueToPath($icon, $defaultIcon);
         $targetPath = $this->outputPath . '/' . basename($realIcon);
+
         if (\file_exists($targetPath)) {
             return $this->webPath . '/' . basename($realIcon);
         }
 
-        $this->imageFactory->create($realIcon, [16, 16, 'center_center'], $targetPath);
+        if (!Path::isAbsolute($realIcon)) {
+            $realIcon = $this->projectWebPath . '/' . $realIcon;
+        }
+
+        $image = $this->imageFactory->create($realIcon, [16, 16, 'center_center'], $targetPath);
 
         return $this->webPath . '/' . basename($realIcon);
     }

--- a/src/CoreBundle/Assets/IconBuilder.php
+++ b/src/CoreBundle/Assets/IconBuilder.php
@@ -85,13 +85,13 @@ class IconBuilder
     /**
      * Create a new instance.
      *
-     * @param Adapter               $filesAdapter Adapter to the Contao files model class.
-     * @param ImageFactoryInterface $imageFactory The image factory for resizing images.
-     * @param string                $rootPath     The root path of the application.
-     * @param string                $outputPath   The output path for assets.
-     * @param string                $webPath      The web reachable path for assets.
-     * @param Adapter               $imageAdapter The image adapter to generate HTML code images.
-     * @param string                $webPath      The project web reachable path for assets.
+     * @param Adapter               $filesAdapter   Adapter to the Contao files model class.
+     * @param ImageFactoryInterface $imageFactory   The image factory for resizing images.
+     * @param string                $rootPath       The root path of the application.
+     * @param string                $outputPath     The output path for assets.
+     * @param string                $webPath        The web reachable path for assets.
+     * @param Adapter               $imageAdapter   The image adapter to generate HTML code images.
+     * @param string                $projectWebPath The project web reachable path for assets.
      */
     public function __construct(
         Adapter $filesAdapter,
@@ -136,7 +136,7 @@ class IconBuilder
             $realIcon = $this->projectWebPath . '/' . $realIcon;
         }
 
-        $image = $this->imageFactory->create($realIcon, [16, 16, 'center_center'], $targetPath);
+        $this->imageFactory->create($realIcon, [16, 16, 'center_center'], $targetPath);
 
         return $this->webPath . '/' . basename($realIcon);
     }

--- a/src/CoreBundle/Resources/config/services.yml
+++ b/src/CoreBundle/Resources/config/services.yml
@@ -8,6 +8,7 @@ services:
             - "%metamodels.assets_dir%"
             - "%metamodels.assets_web%"
             - "@=service('contao.framework').getAdapter('Contao\\\\Image')"
+            - "%contao.web_dir%"
 
     metamodels.cache:
         class: Doctrine\Common\Cache\FilesystemCache


### PR DESCRIPTION
Description

In Contao 4.8 the image factory requires absolute paths (as it was only documented before), see https://github.com/contao/contao/commit/3a48a3dd0a441342121a388f014dce66ea8c4cc0. This leads to errors with the metamodels input mask. 

Disclaimer: I know that MetaModels does not officially support Contao > `^4.4`. However it would be one step closer for the upcoming LTS 4.9.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
