### PR TITLE
Add getters and setters for url settings.

### DIFF
--- a/src/Filter/FilterUrlBuilder.php
+++ b/src/Filter/FilterUrlBuilder.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2019 The MetaModels team.
+ * (c) 2012-2020 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,7 @@
  * @package    MetaModels/core
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright  2012-2019 The MetaModels team.
+ * @copyright  2012-2020 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
@@ -89,6 +89,46 @@ class FilterUrlBuilder
         $this->isLocalePrepended = $isLocalePrepended;
         $this->urlSuffix         = $urlSuffix;
         $this->pageModelAdapter  = $pageModelAdapter;
+    }
+
+    /**
+     * Returns whether locale is prepended.
+     * 
+     * @return bool
+     */
+    public function isLocalePrepended(): bool
+    {
+        return $this->isLocalePrepended;
+    }
+
+    /**
+     * Sets whether locale is prepended.
+     * 
+     * @param bool $isLocalePrepended The setting.
+     */
+    public function setIsLocalePrepended(bool $isLocalePrepended): void
+    {
+        $this->isLocalePrepended = $isLocalePrepended;
+    }
+
+    /**
+     * Gets the url suffix.
+     *
+     * @return string
+     */
+    public function getUrlSuffix(): string
+    {
+        return $this->urlSuffix;
+    }
+
+    /**
+     * Sets the url suffix.
+     *
+     * @param string $urlSuffix The url suffix.
+     */
+    public function setUrlSuffix(string $urlSuffix): void
+    {
+        $this->urlSuffix = $urlSuffix;
     }
 
     /**

--- a/src/Filter/FilterUrlBuilder.php
+++ b/src/Filter/FilterUrlBuilder.php
@@ -93,7 +93,7 @@ class FilterUrlBuilder
 
     /**
      * Returns whether locale is prepended.
-     * 
+     *
      * @return bool
      */
     public function isLocalePrepended(): bool
@@ -103,8 +103,10 @@ class FilterUrlBuilder
 
     /**
      * Sets whether locale is prepended.
-     * 
+     *
      * @param bool $isLocalePrepended The setting.
+     *
+     * @return void
      */
     public function setIsLocalePrepended(bool $isLocalePrepended): void
     {
@@ -125,6 +127,8 @@ class FilterUrlBuilder
      * Sets the url suffix.
      *
      * @param string $urlSuffix The url suffix.
+     *
+     * @return void
      */
     public function setUrlSuffix(string $urlSuffix): void
     {


### PR DESCRIPTION
## Description

I need to change URL suffix on runtime, and decorating the service seems superfluous for me.

I use the URL builder on a custom route. This custom route uses `.ics` as URL suffix. I need the URL builder to strip of the URL suffix.

```php
  /**
     * @Route("/items/{urlParams}.ics", requirements={"urlParams"=".+"})
     */
    public function __invoke(string $urlParams, Request $request)
    {
        $metaModel = $this->metaModelFactory->getMetaModel('mm_test');
        if (null === $metaModel) {
            throw new RuntimeException('Could not instantiate MetaModel: mm_test');
        }
        $filterUrl = $this->filterUrlBuilder->getCurrentFilterUrl();
    }
```

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
