### PR TITLE
[RTM] Fix different max length definition of DCA name fields in SQL and eval array

### DIFF
--- a/src/CoreBundle/Resources/contao/dca/tl_metamodel.php
+++ b/src/CoreBundle/Resources/contao/dca/tl_metamodel.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2019 The MetaModels team.
+ * (c) 2012-2020 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -20,7 +20,8 @@
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
- * @copyright  2012-2019 The MetaModels team.
+ * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
+ * @copyright  2012-2020 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
@@ -540,7 +541,7 @@ $GLOBALS['TL_DCA']['tl_metamodel'] = array
             'eval'      => array
             (
                 'mandatory' => true,
-                'maxlength' => 64,
+                'maxlength' => 255,
                 'tl_class'  => 'w50'
             ),
             'sql'       => "varchar(255) NOT NULL default ''"

--- a/src/CoreBundle/Resources/contao/dca/tl_metamodel_dca.php
+++ b/src/CoreBundle/Resources/contao/dca/tl_metamodel_dca.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2019 The MetaModels team.
+ * (c) 2012-2020 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -20,7 +20,8 @@
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
- * @copyright  2012-2019 The MetaModels team.
+ * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
+ * @copyright  2012-2020 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
@@ -298,7 +299,7 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca'] = array
             'eval'      => array
             (
                 'mandatory' => true,
-                'maxlength' => 64,
+                'maxlength' => 255,
                 'tl_class'  => 'w50'
             ),
             'sql'       => "varchar(255) NOT NULL default ''"

--- a/src/CoreBundle/Resources/contao/dca/tl_metamodel_dca_sortgroup.php
+++ b/src/CoreBundle/Resources/contao/dca/tl_metamodel_dca_sortgroup.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2019 The MetaModels team.
+ * (c) 2012-2020 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,7 +16,8 @@
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
- * @copyright  2012-2019 The MetaModels team.
+ * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
+ * @copyright  2012-2020 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
@@ -252,10 +253,10 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca_sortgroup'] = array
             'eval'      => array
             (
                 'mandatory' => true,
-                'maxlength' => 64,
+                'maxlength' => 255,
                 'tl_class'  => 'w50'
             ),
-            'sql'       => 'text NULL'
+            'sql'       => "varchar(255) NOT NULL default ''"
         ),
         'isdefault'       => array
         (

--- a/src/CoreBundle/Resources/contao/dca/tl_metamodel_filter.php
+++ b/src/CoreBundle/Resources/contao/dca/tl_metamodel_filter.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2019 The MetaModels team.
+ * (c) 2012-2020 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -17,7 +17,8 @@
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright  2012-2019 The MetaModels team.
+ * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
+ * @copyright  2012-2020 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
@@ -213,7 +214,7 @@ $GLOBALS['TL_DCA']['tl_metamodel_filter'] = array
                 'maxlength'           => 255,
                 'tl_class'            => 'w50'
             ),
-            'sql' => "varchar(64) NOT NULL default ''"
+            'sql' => "varchar(255) NOT NULL default ''"
         ),
     )
 );

--- a/src/CoreBundle/Resources/contao/dca/tl_metamodel_rendersettings.php
+++ b/src/CoreBundle/Resources/contao/dca/tl_metamodel_rendersettings.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2019 The MetaModels team.
+ * (c) 2012-2020 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -20,7 +20,8 @@
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
- * @copyright  2012-2019 The MetaModels team.
+ * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
+ * @copyright  2012-2020 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
@@ -239,7 +240,7 @@ $GLOBALS['TL_DCA']['tl_metamodel_rendersettings'] = array
                 'maxlength' => 255,
                 'tl_class'  => 'w50'
             ),
-            'sql'       => "varchar(64) NOT NULL default ''"
+            'sql'       => "varchar(255) NOT NULL default ''"
         ),
         'hideEmptyValues' => array
         (


### PR DESCRIPTION
## Description

Some DCA fields have different max length definition in SQL and eval array. This leads for example to cutted text when saving to the database.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
