### PR TITLE
[RTM] Make the sorting sortable to use the order in the backend list view

### DIFF
--- a/src/CoreBundle/Resources/contao/dca/tl_metamodel_dca_sortgroup.php
+++ b/src/CoreBundle/Resources/contao/dca/tl_metamodel_dca_sortgroup.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2019 The MetaModels team.
+ * (c) 2012-2020 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,7 +16,8 @@
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
- * @copyright  2012-2019 The MetaModels team.
+ * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
+ * @copyright  2012-2020 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
@@ -126,10 +127,9 @@ $GLOBALS['TL_DCA']['tl_metamodel_dca_sortgroup'] = array
         'sorting'           => array
         (
             'mode'         => 4,
-            'fields'       => array('name'),
+            'fields'       => array('sorting'),
             'panelLayout'  => 'limit',
             'headerFields' => array('name'),
-            'flag'         => 1,
         ),
         'label'             => array
         (


### PR DESCRIPTION
implements #1430

## Description

With this PR the sortings can be manually sorted. This sort order will be used to create the sort drop down in the backend list view.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
