### PR TITLE
Correct addFromCurrentRequest

### DIFF
--- a/src/Filter/FilterUrlBuilder.php
+++ b/src/Filter/FilterUrlBuilder.php
@@ -185,6 +185,9 @@ class FilterUrlBuilder
         }
 
         $request = $this->requestStack->getMasterRequest();
+        if (null === $request) {
+            return;
+        }
 
         if (isset($options['preserveGet'])) {
             foreach ($request->query->all() as $name => $value) {


### PR DESCRIPTION
## Description

This fix a problem where the request is null and the whole function addFromCurrentRequest will end in an "Call to a member function all() on null"-error.

@e-spin and @discordier: I think we have to check all request calls for this error. This error happens, because I call the list module over the console, 'cause I create a PDF out of it.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
