### PR TITLE
Fix the renamed method getObjItems to getItems and add BC layer

### DIFF
--- a/src/CoreBundle/Controller/ListControllerTrait.php
+++ b/src/CoreBundle/Controller/ListControllerTrait.php
@@ -185,14 +185,14 @@ trait ListControllerTrait
         }
 
         $template->items         = StringUtil::encodeEmail($itemRenderer->render($model->metamodel_noparsing, $model));
-        $template->numberOfItems = $itemRenderer->getObjItems()->getCount();
+        $template->numberOfItems = $itemRenderer->getItems()->getCount();
         $template->pagination    = $itemRenderer->getPagination();
 
         $responseTags = array_map(
             static function (IItem $item) {
                 return sprintf('contao.db.%s.%d', $item->getMetaModel()->getTableName(), $item->get('id'));
             },
-            iterator_to_array($itemRenderer->getObjItems(), false)
+            iterator_to_array($itemRenderer->getItems(), false)
         );
 
         $response = $template->getResponse();

--- a/src/FrontendIntegration/HybridList.php
+++ b/src/FrontendIntegration/HybridList.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/core.
  *
- * (c) 2012-2019 The MetaModels team.
+ * (c) 2012-2022 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -19,7 +19,7 @@
  * @author     Oliver Hoff <oliver@hofff.com>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright  2012-2019 The MetaModels team.
+ * @copyright  2012-2022 The MetaModels team.
  * @license    https://github.com/MetaModels/core/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
@@ -124,7 +124,7 @@ class HybridList extends MetaModelHybrid
         // Render items with encoded email strings as contao standard.
         $this->Template->items         =
             \StringUtil::encodeEmail($objItemRenderer->render($this->metamodel_noparsing, $this));
-        $this->Template->numberOfItems = $objItemRenderer->getObjItems()->getCount();
+        $this->Template->numberOfItems = $objItemRenderer->getItems()->getCount();
         $this->Template->pagination    = $objItemRenderer->getPagination();
     }
 }

--- a/src/ItemList.php
+++ b/src/ItemList.php
@@ -883,9 +883,27 @@ class ItemList
      *
      * @return IItems
      */
-    public function getObjItems(): IItems
+    public function getItems(): IItems
     {
         return $this->objItems;
+    }
+
+    /**
+     * Returns the item list in the view.
+     *
+     * @return IItems
+     *
+     * @deprecated The method is deprecated and should not be used anymore.
+     */
+    public function getObjItems(): IItems
+    {
+        // @codingStandardsIgnoreStart
+        @trigger_error(
+            '"' .__METHOD__ . '" is deprecated - use \'getItems()\'.',
+            E_USER_DEPRECATED
+        );
+        // @codingStandardsIgnoreEnd
+        return $this->getItems();
     }
 
     /**


### PR DESCRIPTION
Fix the renamed method getObjItems to getItems and add BC layer

fix commit https://github.com/MetaModels/core/commit/fdc408c4914e6202c0362cfad3b450df445126a2#diff-e3b36620f81bc583e1ae275d828897526784d42496c0f06876a037ef9bc8f1e4