### PR TITLE
Allow inspiredminds/contao-file-usage 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
     "contao/manager-bundle": "^5.3.0 <5.7.0",
     "contao/manager-plugin": "^2.8",
     "doctrine/doctrine-bundle": "^2.8.3",
-    "inspiredminds/contao-file-usage": "^3.0.1",
+    "inspiredminds/contao-file-usage": "^3.0.1 || ^4.0",
     "phpcq/runner-bootstrap": "^1.0@dev"
   },
   "autoload": {


### PR DESCRIPTION
Widen the development dependency to the 4.x line so the file usage integration can get tested against it as well.

